### PR TITLE
commands: enhance subscribe/unsubscribe with list, search and batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,28 +113,33 @@ python bot.py
 @lkml-bot /help
 ```
 
-#### `/subscribe <subsystem>`
-订阅一个子系统的邮件列表。订阅后，当该子系统有新邮件或回复时，你会收到通知。
+#### `/subscribe` / `/sub`
+订阅或管理子系统的邮件列表。订阅后，当该子系统有新邮件或回复时，你会收到通知。
 
-**参数：**
-- `<subsystem>`: 子系统名称，如 `lkml`、`rust-for-linux`、`netdev`、`dri-devel` 等
+支持的用法：
 
-**示例：**
-```
-@lkml-bot /subscribe lkml
-@lkml-bot /subscribe rust-for-linux
-```
+- 订阅单个子系统：
+  - `@lkml-bot /subscribe rust-for-linux`
+  - `@lkml-bot /sub rust-for-linux`
+- 批量订阅多个子系统（空格或逗号分隔）：
+  - `@lkml-bot /subscribe linux-kernel netdev dri-devel`
+  - `@lkml-bot /sub linux-kernel,netdev,dri-devel`
+- 查看当前订阅和所有可订阅的子系统（Discord Embed 展示，5 个一行）：
+  - `@lkml-bot /subscribe list`
+- 按关键字模糊搜索可订阅子系统：
+  - `@lkml-bot /subscribe search linux`
 
-#### `/unsubscribe <subsystem>`
-取消订阅一个子系统的邮件列表。
+#### `/unsubscribe` / `/unsub`
+取消订阅一个或多个子系统的邮件列表。
 
-**参数：**
-- `<subsystem>`: 子系统名称
+支持的用法：
 
-**示例：**
-```
-@lkml-bot /unsubscribe lkml
-```
+- 取消订阅单个子系统：
+  - `@lkml-bot /unsubscribe rust-for-linux`
+  - `@lkml-bot /unsub rust-for-linux`
+- 批量取消订阅多个子系统（空格或逗号分隔）：
+  - `@lkml-bot /unsubscribe linux-kernel netdev dri-devel`
+  - `@lkml-bot /unsub linux-kernel,netdev,dri-devel`
 
 #### `/start-monitor`
 启动邮件列表监控定时任务。启动后，机器人会定期检查所有已订阅的子系统，并在发现新邮件时发送通知。
@@ -271,7 +276,7 @@ author_email: /@(?:.*\.)?@gmail\.com$/
 
 ## TODO
 
-- [ ] 实现从服务器缓存获取 vger 子系统列表的功能（`src/lkml/vger_cache.py`）
+- [x] 实现从服务器缓存获取 vger 子系统列表的功能（`src/lkml/vger_cache.py`）
   - Bot 的服务器缓存会存储所有从 vger 获取的内核子系统信息（键值对格式）
   - 需要在 `get_vger_subsystems_from_cache()` 函数中实现从服务器缓存读取逻辑
   - 函数应返回子系统名称列表，例如: `["lkml", "netdev", "dri-devel", ...]`

--- a/src/lkml/feed/vger_subsystems.py
+++ b/src/lkml/feed/vger_subsystems.py
@@ -4,17 +4,210 @@
 外部服务等）由实现决定，调用方无需关心。
 """
 
-from typing import List
+import asyncio
+import re
+from typing import List, Optional
+
+from nonebot.log import logger
+
+VGER_SUBSYSTEMS_URL = "https://subspace.kernel.org/vger.kernel.org.html"
+
+# 模块级缓存变量
+_vger_subsystems_cache: Optional[List[str]] = None
+
+# 表头关键词（需要排除）
+TABLE_HEADER_KEYWORDS = ("name", "description", "fl", "addresses", "subs")
+# 需要排除的前缀
+EXCLUDED_PREFIXES = ("sub", "unsub", "post", "archive", "http", "mailto")
+
+
+def _is_valid_subsystem_name(name: str) -> bool:
+    """验证子系统名称是否有效
+
+    Args:
+        name: 子系统名称
+
+    Returns:
+        如果名称有效返回 True，否则返回 False
+    """
+    if not name or name.isdigit() or len(name) <= 1:
+        return False
+
+    name_lower = name.lower()
+    if name_lower in TABLE_HEADER_KEYWORDS:
+        return False
+
+    if name.startswith(EXCLUDED_PREFIXES):
+        return False
+
+    if "/" in name or "@" in name or " " in name:
+        return False
+
+    # 验证格式：小写字母、数字、连字符
+    return bool(re.match(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$", name))
+
+
+# 每日更新间隔（秒）：24 小时 = 86400 秒
+DAILY_UPDATE_INTERVAL = 24 * 60 * 60
 
 
 def get_vger_subsystems() -> List[str]:
-    """获取 vger 子系统列表
+    """从模块级缓存获取 vger 子系统列表
+
+    Bot 的服务器缓存会存储所有从 vger 获取的内核子系统信息。
+    此函数从模块级缓存变量中读取缓存的子系统列表。
 
     Returns:
         子系统名称列表，例如: ["lkml", "netdev", "dri-devel", ...]
-
-    TODO:
-        根据你的运行环境，从合适的数据源读取（如内存、Redis、数据库或配置文件）。
-        如果暂时没有数据源，返回空列表即可。
+        如果缓存中没有数据，返回空列表。
     """
-    return []
+    try:
+        if _vger_subsystems_cache is not None and isinstance(
+            _vger_subsystems_cache, list
+        ):
+            return _vger_subsystems_cache
+        logger.warning(
+            "Vger subsystems cache not found or invalid, returning empty list"
+        )
+        return []
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f"Failed to get vger subsystems from cache: {e}", exc_info=True)
+        return []
+
+
+async def fetch_vger_subsystems() -> List[str]:
+    """从 vger.kernel.org 网页抓取子系统列表
+
+    从 https://subspace.kernel.org/vger.kernel.org.html 解析 HTML 表格，
+    提取所有子系统的名称。
+
+    Returns:
+        子系统名称列表，例如: ["lkml", "netdev", "dri-devel", ...]
+        如果抓取失败，返回空列表。
+    """
+    try:
+        import httpx  # pylint: disable=import-outside-toplevel
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(VGER_SUBSYSTEMS_URL)
+            response.raise_for_status()
+            html_content = response.text
+
+        # 使用正则表达式从 HTML 表格中提取子系统名称
+        # 表格格式: 每行 <tr> 包含多个 <td>，第一列是子系统名称
+        # 匹配每行的第一个 <td> 标签内容（可能是纯文本或链接）
+        # 模式1: <td>name</td> (纯文本)
+        # 模式2: <td><a ...>name</a></td> (链接)
+        # 模式3: <td>name</td> (可能包含空白)
+
+        # 先提取所有表格行
+        table_rows_pattern = r"<tr[^>]*>(.*?)</tr>"
+        rows = re.findall(table_rows_pattern, html_content, re.DOTALL | re.IGNORECASE)
+
+        subsystems = []
+        for row in rows:
+            # 提取第一个 <td> 的内容
+            # 匹配 <th>...</th>，考虑可能包含 <a> 标签的情况
+            first_th_pattern = r"<th[^>]*>(.*?)</th>"
+            first_th_match = re.search(first_th_pattern, row, re.DOTALL | re.IGNORECASE)
+            if not first_th_match:
+                continue
+
+            th_content = first_th_match.group(1).strip()
+            # 如果包含 <a> 标签，提取链接文本
+            link_pattern = r"<a[^>]*>(.*?)</a>"
+            link_match = re.search(link_pattern, th_content, re.IGNORECASE)
+            if link_match:
+                name = link_match.group(1).strip()
+            else:
+                name = re.sub(r"<[^>]+>", "", th_content).strip()  # 移除所有 HTML 标签
+
+            # 验证子系统名称格式：小写字母、数字、连字符
+            # 排除表头、空字符串、数字、URL、邮箱等
+            if _is_valid_subsystem_name(name):
+                subsystems.append(name)
+
+        # 去重并排序
+        subsystems = sorted(list(set(subsystems)))
+
+        logger.info(
+            f"Fetched {len(subsystems)} vger subsystems from {VGER_SUBSYSTEMS_URL}"
+        )
+        return subsystems
+
+    except ImportError:
+        logger.error("httpx is not installed, cannot fetch vger subsystems")
+        return []
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f"Failed to fetch vger subsystems: {e}", exc_info=True)
+        return []
+
+
+async def update_vger_subsystems_cache() -> bool:
+    """更新模块级缓存中的 vger 子系统列表
+
+    从 vger.kernel.org 抓取最新的子系统列表，并存储到模块级缓存变量中。
+
+    Returns:
+        如果更新成功返回 True，否则返回 False。
+    """
+    global _vger_subsystems_cache  # pylint: disable=global-statement
+    try:
+        subsystems = await fetch_vger_subsystems()
+        if not subsystems:
+            logger.warning("No subsystems fetched, cache not updated")
+            return False
+
+        # 存储到模块级缓存变量
+        _vger_subsystems_cache = subsystems
+        logger.info(
+            f"Updated vger subsystems cache with {len(subsystems)} subsystems: "
+            f"{', '.join(subsystems[:10])}{'...' if len(subsystems) > 10 else ''}"
+        )
+        return True
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f"Failed to update vger subsystems cache: {e}", exc_info=True)
+        return False
+
+
+async def daily_update_task() -> None:
+    """每日更新 vger 子系统缓存的定时任务
+
+    此任务会每天自动执行一次，更新服务器缓存中的 vger 子系统列表。
+    """
+    logger.info("Starting daily vger subsystems cache update task")
+
+    while True:
+        try:
+            # 等待一天（24小时）
+            await asyncio.sleep(DAILY_UPDATE_INTERVAL)
+
+            logger.info("Running scheduled daily update of vger subsystems cache")
+            success = await update_vger_subsystems_cache()
+            if success:
+                logger.info("Daily vger subsystems cache update completed successfully")
+            else:
+                logger.warning(
+                    "Daily vger subsystems cache update failed, will retry tomorrow"
+                )
+        except asyncio.CancelledError:
+            logger.info("Daily vger subsystems cache update task cancelled")
+            break
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(
+                f"Error in daily vger subsystems cache update task: {e}",
+                exc_info=True,
+            )
+            # 出错时等待1小时后重试，避免连续失败
+            await asyncio.sleep(3600)
+
+
+def start_daily_update_task() -> asyncio.Task:
+    """启动每日更新任务
+
+    Returns:
+        创建的 asyncio.Task 对象，可用于取消任务
+    """
+    task = asyncio.create_task(daily_update_task())
+    logger.info("Daily vger subsystems cache update task started")
+    return task

--- a/src/plugins/lkml_bot/commands/subscribe.py
+++ b/src/plugins/lkml_bot/commands/subscribe.py
@@ -1,7 +1,10 @@
 """订阅子系统命令模块"""
 
-from nonebot import on_message
 import re
+from typing import Optional
+
+import httpx
+from nonebot import on_message
 from nonebot.adapters import Event, Message
 from nonebot.exception import FinishedException
 from nonebot.log import logger
@@ -12,7 +15,31 @@ from lkml.service import LKMLService
 from ..config import get_config
 from ..shared import extract_command, get_user_info_or_finish, register_command
 
+# Discord 相关常量
+DISCORD_EMBED_DESCRIPTION_MAX = 4096  # Discord Embed description 最大长度
+
 lkml_service = LKMLService()
+
+
+def _format_names_multiline(names: list[str], per_line: int = 5) -> str:
+    """将名称列表格式化为每行固定数量的字符串。
+
+    Args:
+        names: 名称列表
+        per_line: 每行的名称数量
+
+    Returns:
+        多行字符串，每行最多包含 per_line 个名称，使用逗号分隔。
+    """
+    if not names:
+        return "无"
+
+    chunks: list[str] = []
+    for i in range(0, len(names), per_line):
+        chunk = ", ".join(names[i : i + per_line])
+        chunks.append(chunk)
+    return "\n".join(chunks)
+
 
 # 仅当消息 @ 到机器人，并且以 "/subscribe" 开头时处理
 # 优先级设为 50，高于 help (40)，确保优先匹配
@@ -43,23 +70,44 @@ async def handle_subscribe(event: Event, message: Message = EventMessage()):
             return
 
         parts = command_text.split()
-        if len(parts) < 2:
+
+        # 如果没有参数，显示帮助信息
+        if len(parts) == 0:
             await SubscribeCmd.finish(
-                "subscribe: 缺少参数\n用法: @机器人 /subscribe|/sub <subsystem...>\n子命令: available | subscribed"
+                "subscribe: 缺少参数\n"
+                "用法: @机器人 /subscribe|/sub <subsystem...> | list | search <keyword>\n"
+                "示例:\n"
+                "  /subscribe list - 查看当前订阅列表\n"
+                "  /subscribe search net - 搜索包含 'net' 的子系统\n"
+                "  /subscribe netdev dri-devel - 批量订阅多个子系统"
             )
             return
 
-        action = parts[1].strip().lower()
-        logger.info("Processing subscribe request, action: %s", action)
+        # 检查第一个参数是否是已知的子命令
+        first_arg = parts[1].strip().lower()
 
-        # 获取用户信息
-        user_id, user_name = await get_user_info_or_finish(event, SubscribeCmd)
+        logger.info(f"First argument: {first_arg}")
 
-        if action == "list":
-            await _handle_subscribe_list()
+        if first_arg == "list":
+            await _handle_subscribe_list(event)
             return
 
-        await _handle_subscribe_batch(action, parts, user_id, user_name)
+        if first_arg == "search":
+            if len(parts) < 3:
+                await SubscribeCmd.finish(
+                    "subscribe search: 缺少搜索关键词\n"
+                    "用法: @机器人 /subscribe search <keyword>"
+                )
+                return
+            keyword = " ".join(parts[2:]).strip()
+            logger.info(f"Keyword: {keyword}")
+            await _handle_subscribe_search(keyword, event)
+            return
+
+        # 如果不是子命令，则将所有参数视为子系统名称进行批量订阅
+        # 获取用户信息
+        user_id, user_name = await get_user_info_or_finish(event, SubscribeCmd)
+        await _handle_subscribe_batch(parts, user_id, user_name)
     except FinishedException:  # pylint: disable=try-except-raise
         # FinishedException 由 matcher.finish() 抛出，需要重新抛出以终止处理
         raise
@@ -68,19 +116,19 @@ async def handle_subscribe(event: Event, message: Message = EventMessage()):
         await SubscribeCmd.finish(f"❌ 处理命令时发生错误: {str(e)}")
 
 
-async def _handle_subscribe_list() -> None:
-    """处理订阅列表查询逻辑。"""
+async def _handle_subscribe_list(event: Optional[Event] = None) -> None:
+    """处理订阅列表查询逻辑。
+
+    Args:
+        event: 事件对象
+    """
     try:
         config = get_config()
         supported = config.get_supported_subsystems()
         subscribed = await lkml_service.get_subscribed_subsystems()
-        await SubscribeCmd.finish(
-            "可订阅的子系统: "
-            + ", ".join(supported)
-            + "\n"
-            + "已订阅的子系统: "
-            + ", ".join(subscribed)
-        )
+        subscribed_set = set(subscribed)
+
+        await _send_discord_embed_list(subscribed, subscribed_set, supported, event)
     except FinishedException:
         raise
     except (ValueError, RuntimeError, AttributeError) as e:
@@ -88,11 +136,161 @@ async def _handle_subscribe_list() -> None:
         await SubscribeCmd.finish(f"❌ 列表查询时发生错误: {str(e)}")
 
 
-async def _handle_subscribe_batch(
-    _action: str, parts: list[str], user_id: str, user_name: str
+async def _send_subscribed_embed(
+    channel_id: str, headers: dict, subscribed: list[str]
 ) -> None:
-    """处理批量订阅逻辑。"""
-    raw_args = " ".join(parts[1:])
+    """发送已订阅列表的 Embed
+
+    Args:
+        channel_id: Discord 频道 ID
+        headers: HTTP 请求头
+        subscribed: 已订阅的子系统列表
+    """
+    if subscribed:
+        subscribed_sorted = sorted(subscribed)
+        subscribed_text = _format_names_multiline(subscribed_sorted)
+        # Discord Embed description 最大长度限制
+        if len(subscribed_text) > DISCORD_EMBED_DESCRIPTION_MAX:
+            subscribed_text = (
+                subscribed_text[: DISCORD_EMBED_DESCRIPTION_MAX - 50] + "..."
+            )
+    else:
+        subscribed_text = "无"
+
+    embed = {
+        "title": f"✅ 已订阅 ({len(subscribed)})",
+        "description": subscribed_text,
+        "color": 0x5865F2,  # Discord 蓝色
+        "footer": {"text": "LKML Bot"},
+    }
+
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            json={"embeds": [embed]},
+            headers=headers,
+            timeout=30.0,
+        )
+
+
+async def _send_discord_embed_list(
+    subscribed: list[str],
+    subscribed_set: set[str],
+    supported: list[str],
+    event: Optional[Event] = None,
+) -> None:
+    """使用 Discord Embed 格式发送订阅列表
+
+    Args:
+        subscribed: 已订阅的子系统列表
+        subscribed_set: 已订阅的子系统集合
+        supported: 所有可订阅的子系统列表
+        event: 事件对象
+    """
+    try:
+        config = get_config()
+        if not config.discord_bot_token or not config.platform_channel_id:
+            await SubscribeCmd.finish("❌ Discord 配置未设置")
+            return
+
+        channel_id = config.platform_channel_id
+        if event and hasattr(event, "channel_id"):
+            channel_id = str(event.channel_id)
+
+        headers = {
+            "Authorization": f"Bot {config.discord_bot_token}",
+            "Content-Type": "application/json",
+        }
+
+        # 发送已订阅列表
+        await _send_subscribed_embed(channel_id, headers, subscribed)
+
+        # 发送可订阅列表（不分页，每行固定数量）
+        unsubscribed = sorted(
+            [name for name in supported if name not in subscribed_set]
+        )
+        unsubscribed_text = _format_names_multiline(unsubscribed)
+
+        # Discord Embed description 最大长度限制
+        if len(unsubscribed_text) > DISCORD_EMBED_DESCRIPTION_MAX:
+            unsubscribed_text = (
+                unsubscribed_text[: DISCORD_EMBED_DESCRIPTION_MAX - 50] + "..."
+            )
+
+        unsubscribed_embed = {
+            "title": f"📦 可订阅的子系统 ({len(unsubscribed)})",
+            "description": unsubscribed_text,
+            "color": 0x3498DB,  # 蓝色
+            "footer": {"text": "LKML Bot"},
+        }
+
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"https://discord.com/api/v10/channels/{channel_id}/messages",
+                json={"embeds": [unsubscribed_embed]},
+                headers=headers,
+                timeout=30.0,
+            )
+
+        await SubscribeCmd.finish()
+
+    except FinishedException:
+        # 正常结束流程，向上抛出让 NoneBot 处理
+        raise
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error(f"Error sending Discord embed list: {e}", exc_info=True)
+        await SubscribeCmd.finish(f"❌ 发送订阅列表时发生错误: {str(e)}")
+
+
+async def _handle_subscribe_search(keyword: str, event: Optional[Event] = None) -> None:
+    """处理搜索子系统逻辑。
+
+    Args:
+        keyword: 搜索关键词
+        event: 事件对象（用于获取 Discord 渠道 ID）
+    """
+    try:
+        config = get_config()
+        supported = config.get_supported_subsystems()
+        logger.info(f"Supported subsystems: {supported}")
+        subscribed = await lkml_service.get_subscribed_subsystems()
+        subscribed_set = set(subscribed)
+
+        # 模糊搜索：包含关键词的子系统（不区分大小写）
+        keyword_lower = keyword.lower()
+        matches = [name for name in supported if keyword_lower in name.lower()]
+
+        if not matches:
+            await SubscribeCmd.finish(
+                f"🔍 搜索 '{keyword}': 未找到匹配的子系统\n"
+                f"提示: 使用 /subscribe list 查看所有可订阅的子系统"
+            )
+            return
+
+        # 按订阅状态和名称排序
+        matches.sort(key=lambda x: (x not in subscribed_set, x.lower()))
+
+        await _send_search_result(keyword, matches, subscribed_set, config, event)
+    except FinishedException:
+        raise
+    except (ValueError, RuntimeError, AttributeError) as e:
+        logger.error("Error in search subcommand: %s", e, exc_info=True)
+        await SubscribeCmd.finish(f"❌ 搜索时发生错误: {str(e)}")
+
+
+async def _handle_subscribe_batch(
+    parts: list[str], user_id: str, user_name: str
+) -> None:
+    """处理批量订阅逻辑。
+
+    Args:
+        parts: 命令参数列表（parts[0] 是命令本身，需要排除）
+        user_id: 用户ID
+        user_name: 用户名称
+    """
+    # 将所有部分合并，支持逗号或空格分隔
+    # parts[0] 是命令本身（/subscribe 或 /sub），需要排除
+    raw_args = " ".join(parts[1:]) if len(parts) > 1 else ""
     targets = [x.strip() for x in re.split(r"[,\s]+", raw_args) if x.strip()]
     if not targets:
         await SubscribeCmd.finish("subscribe: 子系统名称不能为空")
@@ -164,10 +362,86 @@ async def _subscribe_targets(
     return lines
 
 
+async def _send_search_result(
+    keyword: str,
+    matches: list[str],
+    subscribed_set: set[str],
+    config,
+    event: Optional[Event] = None,
+) -> None:
+    """根据搜索结果发送 Discord Embed 或文本消息。
+
+    拆分自 _handle_subscribe_search 以减少局部变量数量。
+    """
+    # 将匹配结果按订阅状态拆分
+    subscribed_matches = [m for m in matches if m in subscribed_set]
+    unsubscribed_matches = [m for m in matches if m not in subscribed_set]
+
+    # 如果 Discord 配置不可用，退回到文本输出
+    if not config.discord_bot_token or not config.platform_channel_id:
+        lines = [f"🔍 搜索 '{keyword}' 的结果 ({len(matches)}):"]
+        if subscribed_matches:
+            subscribed_text = _format_names_multiline(sorted(subscribed_matches))
+            lines.append(f"✅ 已订阅:\n{subscribed_text}")
+        if unsubscribed_matches:
+            unsubscribed_text = _format_names_multiline(sorted(unsubscribed_matches))
+            lines.append(f"📦 未订阅:\n{unsubscribed_text}")
+        await SubscribeCmd.finish("\n".join(lines))
+        return
+
+    # Discord 渠道 ID：优先使用事件中的 channel_id，其次使用配置
+    channel_id = config.platform_channel_id
+    if event and hasattr(event, "channel_id"):
+        channel_id = str(event.channel_id)
+
+    # 构造 Embed 内容，样式参考订阅列表（每行最多 5 个）
+    subscribed_text = (
+        _format_names_multiline(sorted(subscribed_matches))
+        if subscribed_matches
+        else "无"
+    )
+    unsubscribed_text = (
+        _format_names_multiline(sorted(unsubscribed_matches))
+        if unsubscribed_matches
+        else "无"
+    )
+
+    description = (
+        f"✅ 已订阅 ({len(subscribed_matches)}): {subscribed_text}\n\n"
+        f"📦 未订阅 ({len(unsubscribed_matches)}): {unsubscribed_text}"
+    )
+
+    # 简单保护，避免超过 Discord Embed 的 description 限制
+    if len(description) > DISCORD_EMBED_DESCRIPTION_MAX:
+        description = description[: DISCORD_EMBED_DESCRIPTION_MAX - 50] + "..."
+
+    embed = {
+        "title": f"🔍 搜索 '{keyword}' 的结果 ({len(matches)})",
+        "description": description,
+        "color": 0x3498DB,  # 蓝色，与可订阅子系统列表一致
+        "footer": {"text": "LKML Bot"},
+    }
+
+    headers = {
+        "Authorization": f"Bot {config.discord_bot_token}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            json={"embeds": [embed]},
+            headers=headers,
+            timeout=30.0,
+        )
+
+    await SubscribeCmd.finish()
+
+
 # 在导入时注册命令元信息（非管理员命令）
 register_command(
     name="subscribe",
-    usage="/(subscribe | sub) <subsystem...> | list",
-    description="订阅子系统；查询可订阅/已订阅列表",
+    usage="/(subscribe | sub) <subsystem...> | list | search <keyword>",
+    description="订阅子系统；查看订阅列表；搜索子系统；批量订阅",
     admin_only=False,
 )

--- a/src/plugins/lkml_bot/commands/unsubscribe.py
+++ b/src/plugins/lkml_bot/commands/unsubscribe.py
@@ -1,5 +1,7 @@
 """取消订阅子系统命令模块"""
 
+import re
+
 from nonebot import on_message
 from nonebot.adapters import Event, Message
 from nonebot.exception import FinishedException
@@ -13,59 +15,48 @@ from ..shared import extract_command, get_user_info_or_finish, register_command
 lkml_service = LKMLService()
 
 
-# 仅当消息 @ 到机器人，并且以 "/unsubscribe" 开头时处理
+# 仅当消息 @ 到机器人，并且以 "/unsubscribe" 或 "/unsub" 开头时处理
 UnsubscribeCmd = on_message(rule=to_me(), priority=50, block=False)
 
 
 @UnsubscribeCmd.handle()
 async def handle_unsubscribe(event: Event, message: Message = EventMessage()):
-    """处理取消订阅命令"""
+    """处理取消订阅命令（支持 /unsubscribe 和 /unsub，支持批量取消）"""
     try:
         text = message.extract_plain_text().strip()
 
-        # 检查命令匹配
-        command_text = extract_command(text, "/unsubscribe")
+        # 检查命令匹配：同时支持 /unsubscribe 和 /unsub
+        command_text = extract_command(text, "/unsubscribe") or extract_command(
+            text, "/unsub"
+        )
         if command_text is None:
             logger.debug(
-                f"Text does not match '/unsubscribe', returning. Text: '{text}'"
+                "Text does not match '/unsubscribe' or '/unsub', returning. "
+                f"Text: '{text}'"
             )
             return
 
         # 解析命令参数
         parts = command_text.split()
-        if len(parts) < 2:
+        if len(parts) == 0:
             await UnsubscribeCmd.finish(
-                "unsubscribe: 缺少 <subsystem>\n用法: @机器人 /unsubscribe <subsystem>"
+                "unsubscribe: 缺少参数\n"
+                "用法: @机器人 (unsubscribe | unsub) <subsystem...>\n"
+                "示例:\n"
+                "  /unsub linux-kernel\n"
+                "  /unsub linux-kernel netdev dri-devel"
             )
             return
 
-        subsystem = parts[1].strip()
-
-        if not subsystem:
+        # 支持批量：用空格或逗号分隔多个子系统名称
+        # 第一个 token 是命令本身（/unsubscribe 或 /unsub），需要排除
+        raw_args = " ".join(parts[1:])
+        targets = [x.strip() for x in re.split(r"[,\s]+", raw_args) if x.strip()]
+        if not targets:
             await UnsubscribeCmd.finish("unsubscribe: 子系统名称不能为空")
             return
 
-        # 获取用户信息
-        user_id, user_name = await get_user_info_or_finish(event, UnsubscribeCmd)
-
-        # 调用服务进行退订
-        try:
-            success = await lkml_service.unsubscribe_subsystem(
-                operator_id=str(user_id),
-                operator_name=str(user_name),
-                subsystem_name=subsystem,
-            )
-
-            if success:
-                await UnsubscribeCmd.finish(f"✅ 已取消订阅子系统: {subsystem}")
-            else:
-                await UnsubscribeCmd.finish("❌ 取消订阅失败，子系统可能不存在或未订阅")
-        except FinishedException:  # pylint: disable=try-except-raise
-            # FinishedException 由 matcher.finish() 抛出，需要重新抛出以终止处理
-            raise
-        except (ValueError, RuntimeError, AttributeError) as e:
-            logger.error(f"Error in unsubscribe_subsystem: {e}", exc_info=True)
-            await UnsubscribeCmd.finish(f"❌ 取消订阅时发生错误: {str(e)}")
+        await _batch_unsubscribe(targets, event)
     except FinishedException:  # pylint: disable=try-except-raise
         # FinishedException 由 matcher.finish() 抛出，需要重新抛出以终止处理
         raise
@@ -74,10 +65,54 @@ async def handle_unsubscribe(event: Event, message: Message = EventMessage()):
         await UnsubscribeCmd.finish(f"❌ 处理命令时发生错误: {str(e)}")
 
 
+async def _batch_unsubscribe(targets: list[str], event: Event) -> None:
+    """执行批量取消订阅逻辑并发送结果。"""
+    # 获取用户信息
+    user_id, user_name = await get_user_info_or_finish(event, UnsubscribeCmd)
+
+    removed: list[str] = []
+    failed: list[str] = []
+
+    for name in sorted(set(targets)):
+        try:
+            ok = await lkml_service.unsubscribe_subsystem(
+                operator_id=str(user_id),
+                operator_name=str(user_name),
+                subsystem_name=name,
+            )
+            if ok:
+                removed.append(name)
+            else:
+                failed.append(name)
+        except FinishedException:  # pylint: disable=try-except-raise
+            raise
+        except (ValueError, RuntimeError, AttributeError) as e:
+            logger.error("Error unsubscribing %s: %s", name, e, exc_info=True)
+            failed.append(name)
+
+    # 根据结果构造反馈
+    if len(targets) == 1:
+        # 单个目标时，保持原来的简洁提示
+        name = targets[0]
+        if name in removed:
+            await UnsubscribeCmd.finish(f"✅ 已取消订阅子系统: {name}")
+        else:
+            await UnsubscribeCmd.finish("❌ 取消订阅失败，子系统可能不存在或未订阅")
+        return
+
+    lines: list[str] = ["unsubscribe: 批量取消订阅结果"]
+    if removed:
+        lines.append("✅ 已取消: " + ", ".join(removed))
+    if failed:
+        lines.append("⚠️ 失败: " + ", ".join(failed))
+
+    await UnsubscribeCmd.finish("\n".join(lines))
+
+
 # 在导入时注册命令元信息（非管理员命令）
 register_command(
     name="unsubscribe",
-    usage="/unsubscribe <subsystem>",
-    description="取消订阅一个子系统的邮件列表",
+    usage="/(unsubscribe | unsub) <subsystem...>",
+    description="取消订阅一个或多个子系统的邮件列表",
     admin_only=False,
 )


### PR DESCRIPTION
## Summary

Implements the enhancements requested in #7:
- `/subscribe list` - Display current subscriptions and available subsystems via Discord embeds
- Batch subscription - Subscribe to multiple subsystems in one command: `/subscribe sub1 sub2 sub3`
- Fuzzy search - Search subsystems by keyword: `/subscribe search <keyword>`

Also adds `/unsub` alias and batch unsubscribe support for consistency.

## Changes

- Add vger subsystems cache with daily auto-update
- Refactor subscribe command to support list/search subcommands
- Add Discord embed formatting for better readability (5 items per line)
- Add batch unsubscribe with `/unsub` alias
- Improve error handling and code organization

## Testing

- Tested `/subscribe list` with various subscription states
- Tested batch subscription with multiple subsystems
- Tested search functionality with different keywords
- Tested batch unsubscribe with `/unsub` alias

Closes #7