### PR TITLE
Feature: Reply-Driven Patch Card Auto-Watch with Filter-Based Gating

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,9 +29,7 @@ if not getattr(driver, "_adapters", None):
     # 优先使用兼容性适配器，如果导入失败则使用原始适配器
     try:
         try:
-            from plugins.lkml_bot.adapters.discord_compat_adapter import (
-                CompatibleDiscordAdapter,
-            )
+            from compat.discord_compat_adapter import CompatibleDiscordAdapter
 
             driver.register_adapter(CompatibleDiscordAdapter)
             logger.info(

--- a/src/compat/__init__.py
+++ b/src/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility helpers for adapters."""

--- a/src/compat/discord_compat_adapter.py
+++ b/src/compat/discord_compat_adapter.py
@@ -6,20 +6,21 @@
 
 import asyncio
 from typing import Optional
+
 from pydantic import ValidationError
 
-from nonebot.log import logger
-from nonebot.exception import WebSocketClosed
 from nonebot.adapters.discord import Adapter as DiscordAdapter
 from nonebot.adapters.discord.event import Event as DiscordEvent, MessageEvent
 from nonebot.adapters.discord.payload import (
     Dispatch,
     Heartbeat,
     HeartbeatAck,
-    Reconnect,
     InvalidSession,
     Payload,
+    Reconnect,
 )
+from nonebot.exception import WebSocketClosed
+from nonebot.log import logger
 
 
 class CompatibleDiscordAdapter(DiscordAdapter):
@@ -51,7 +52,7 @@ class CompatibleDiscordAdapter(DiscordAdapter):
         except ValidationError as e:
             # 捕获 Pydantic 验证错误
             logger.error(
-                f"Discord event validation error (ignored to prevent crash): "
+                "Discord event validation error (ignored to prevent crash): "
                 f"event_type={event_type}, sequence={sequence}, "
                 f"errors={len(e.errors())}"
             )
@@ -68,7 +69,7 @@ class CompatibleDiscordAdapter(DiscordAdapter):
         except (RuntimeError, ValueError, AttributeError, TypeError, OSError) as e:
             # 捕获常见的运行时异常，记录但不抛出
             logger.error(
-                f"Unexpected error parsing Discord event (ignored to prevent crash): "
+                "Unexpected error parsing Discord event (ignored to prevent crash): "
                 f"event_type={event_type}, sequence={sequence}, "
                 f"error={type(e).__name__}: {e}",
                 exc_info=True,
@@ -91,7 +92,7 @@ class CompatibleDiscordAdapter(DiscordAdapter):
         if event is None:
             # 如果事件解析失败（返回 None），跳过这个事件
             logger.debug(
-                f"Skipping event due to validation error: "
+                "Skipping event due to validation error: "
                 f"type={payload.type}, sequence={payload.sequence}"
             )
             return True
@@ -198,7 +199,7 @@ class CompatibleDiscordAdapter(DiscordAdapter):
         ):
             # 捕获常见的运行时异常，记录但不中断循环
             logger.error(
-                f"Error in Discord adapter loop (continuing to prevent crash): "
+                "Error in Discord adapter loop (continuing to prevent crash): "
                 f"{type(exception).__name__}: {exception}",
                 exc_info=True,
             )
@@ -207,7 +208,7 @@ class CompatibleDiscordAdapter(DiscordAdapter):
             return True
         # 其他未知异常，记录但不中断循环
         logger.error(
-            f"Unexpected error in Discord adapter loop (continuing): "
+            "Unexpected error in Discord adapter loop (continuing): "
             f"{type(exception).__name__}: {exception}",
             exc_info=True,
         )

--- a/src/lkml/db/repo/filter_config_repository.py
+++ b/src/lkml/db/repo/filter_config_repository.py
@@ -194,3 +194,27 @@ class FilterConfigRepository:
             enabled,
             "独占模式：True=只允许匹配的创建，False=所有都创建但高亮匹配的",
         )
+
+    async def get_auto_watch_enabled(self) -> bool:
+        """获取自动 watch 配置
+
+        Returns:
+            是否启用自动 watch，默认 False
+        """
+        value = await self.get("reply_auto_watch", False)
+        return bool(value)
+
+    async def set_auto_watch_enabled(self, enabled: bool) -> FilterConfigData:
+        """设置自动 watch 配置
+
+        Args:
+            enabled: 是否启用自动 watch
+
+        Returns:
+            配置数据
+        """
+        return await self.set(
+            "reply_auto_watch",
+            enabled,
+            "自动 watch：True=满足规则自动 watch，False=关闭",
+        )

--- a/src/lkml/feed/cc_fetcher.py
+++ b/src/lkml/feed/cc_fetcher.py
@@ -38,8 +38,15 @@ def _clean_html_text(text: str) -> str:
     Returns:
         清理后的文本
     """
-    # 移除 HTML 标签
-    text = re.sub(r"<[^>]+>", " ", text)
+    if not text:
+        return ""
+
+    # 先保留形如 <email@domain> 的邮箱，避免被当成 HTML 标签移除
+    email_in_brackets = r"<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>"
+    text = re.sub(email_in_brackets, r"\1", text)
+
+    # 移除 HTML 标签（保留标签内部文本）
+    text = re.sub(r"</?\w+[^>]*>", " ", text)
     # 清理空白字符
     text = re.sub(r"\s+", " ", text).strip()
     return text

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -9,8 +9,10 @@
 - Service 层负责业务逻辑（PatchCardService, ThreadService, FeedMessageService）
 """
 
+# pylint: disable=too-many-lines
+
 import logging
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,10 +26,19 @@ from .types import (
     PatchCard,
     PatchThread,
     SeriesPatchInfo,
+    ThreadOverviewData,
 )
 from .patch_card_service import PatchCardService
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ReplyNotificationSender(Protocol):
+    """Protocol for reply notification sender."""
+
+    async def send_reply_notification(self, payload: dict) -> None:
+        """Send a reply notification."""
 
 
 class FeedMessageService:
@@ -164,6 +175,10 @@ class FeedMessageService:
                     feed_message.message_id_header
                 )
 
+            auto_watch_enabled = await self._is_auto_watch_enabled(
+                session, matched_filters
+            )
+
             # PATCH 卡片不存在，准备创建
             if not patch_card:
                 patch_card = await self._create_and_send_patch_card(  # pylint: disable=too-many-arguments
@@ -181,6 +196,8 @@ class FeedMessageService:
                     f"is_series={classification.is_series_patch}, "
                     f"platform_message_id={patch_card.platform_message_id}"
                 )
+                if auto_watch_enabled and not patch_card.has_thread:
+                    await self._auto_watch_patch_card(session, patch_card)
             else:
                 logger.warning(
                     f"Failed to create PATCH card for: {feed_message.message_id_header}, "
@@ -341,14 +358,17 @@ class FeedMessageService:
             session, feed_message
         )
 
-        if not patch_card or not thread or not thread.is_active:
+        # 已建立并激活 Thread：保持现状，仅更新 Thread
+        if patch_card and thread and thread.is_active:
+            # 更新 Thread：如果是多消息模式，只更新对应的子 PATCH 消息
+            # 传入 session 以确保能查询到新保存的 REPLY（还在同一事务中）
+            await self._update_thread_with_reply(
+                session, thread, patch_card, feed_message.in_reply_to_header
+            )
             return
 
-        # 更新 Thread：如果是多消息模式，只更新对应的子 PATCH 消息
-        # 传入 session 以确保能查询到新保存的 REPLY（还在同一事务中）
-        await self._update_thread_with_reply(
-            session, thread, patch_card, feed_message.in_reply_to_header
-        )
+        # Reply Perspective：未建立 Thread 或无卡片时的补充处理
+        await self._process_reply_perspective(session, feed_message, patch_card)
 
     async def _find_patch_card_and_thread_for_reply(
         self, session: AsyncSession, feed_message: FeedMessageData
@@ -440,6 +460,310 @@ class FeedMessageService:
 
         return patch_card
 
+    async def _process_reply_perspective(
+        self,
+        session: AsyncSession,
+        reply_message: FeedMessageData,
+        existing_patch_card: Optional[PatchCard],
+    ) -> None:
+        """Reply Perspective 处理逻辑
+
+        规则：
+        - 如果 Reply 对应的 Patch 已建立 Thread（has_thread=True），不做额外处理
+        - 如果 Patch Card 不存在：根据过滤规则创建并推送 Patch Card，然后自动 watch
+        - 如果 Patch Card 已存在但未 watch：自动 watch
+        """
+        try:
+            patch_context = await self._build_reply_patch_context(
+                session, reply_message
+            )
+            if not patch_context:
+                return
+
+            target_patch, patch_info, service_feed_message, matched_filters = (
+                patch_context
+            )
+
+            if matched_filters:
+                service_feed_message.matched_filters = matched_filters
+
+            patch_card = await self._get_existing_patch_card_for_reply(
+                session, existing_patch_card, target_patch
+            )
+
+            if patch_card and patch_card.has_thread:
+                return
+
+            # Patch Card 不存在：创建并推送
+            if not patch_card:
+                created_card = await self._create_and_send_patch_card(  # pylint: disable=too-many-arguments
+                    session,
+                    target_patch,
+                    service_feed_message,
+                    patch_info,
+                    target_patch.series_message_id,
+                )
+                if created_card:
+                    logger.info(
+                        "Created PATCH card via reply perspective: %s",
+                        target_patch.message_id_header,
+                    )
+                patch_card = created_card
+
+            if not patch_card:
+                return
+
+            await self._send_reply_notice(reply_message, target_patch)
+
+            if await self._is_auto_watch_enabled(session, matched_filters):
+                await self._auto_watch_patch_card(session, patch_card)
+        except (RuntimeError, ValueError, AttributeError) as e:
+            logger.error(
+                "Failed to process reply perspective: %s",
+                e,
+                exc_info=True,
+            )
+
+    async def _build_reply_patch_context(
+        self, session: AsyncSession, reply_message: FeedMessageData
+    ) -> Optional[tuple[FeedMessageData, object, ServiceFeedMessage, list[str]]]:
+        """构建 Reply 视角处理上下文（目标 Patch + 过滤信息）"""
+        target_patch = await self._resolve_patch_feed_message_for_reply(
+            session, reply_message
+        )
+        if not target_patch or not target_patch.subject:
+            return None
+
+        from ..feed.feed_message_classifier import parse_patch_subject
+
+        patch_info = parse_patch_subject(target_patch.subject)
+        if not patch_info or not patch_info.is_patch:
+            return None
+
+        # Reply 视角过滤：使用 reply 内容判断是否命中规则
+        filter_message = self._convert_to_service_feed_message(
+            reply_message, patch_info, target_patch.series_message_id
+        )
+        should_create, matched_filters = await self._should_create_patch_card(
+            session, filter_message, patch_info
+        )
+        if not should_create:
+            return None
+        if not matched_filters:
+            # Reply 视角必须命中过滤规则才触发后续处理
+            return None
+
+        # Patch Card 创建数据仍使用 Patch 本身
+        service_feed_message = self._convert_to_service_feed_message(
+            target_patch, patch_info, target_patch.series_message_id
+        )
+
+        return target_patch, patch_info, service_feed_message, matched_filters
+
+    async def _get_existing_patch_card_for_reply(
+        self,
+        session: AsyncSession,
+        existing_patch_card: Optional[PatchCard],
+        target_patch: FeedMessageData,
+    ) -> Optional[PatchCard]:
+        """获取 Reply 对应的 PatchCard"""
+        if existing_patch_card:
+            return existing_patch_card
+
+        from .helpers import create_repositories_and_services
+
+        (_, _, _, patch_card_service, _) = create_repositories_and_services(session)
+        return await self._find_patch_card_for_feed_message(
+            patch_card_service, target_patch
+        )
+
+    async def _is_auto_watch_enabled(
+        self, session: AsyncSession, matched_filters: Optional[list[str]]
+    ) -> bool:
+        """判断是否允许自动 watch（需要命中过滤规则且全局开关开启）"""
+        if not matched_filters:
+            return False
+        from ..db.repo import FilterConfigRepository
+
+        config_repo = FilterConfigRepository(session)
+        return await config_repo.get_auto_watch_enabled()
+
+    async def _send_reply_notice(
+        self, reply_message: FeedMessageData, root_patch: FeedMessageData
+    ) -> None:
+        """发送 Reply 视角通知消息"""
+        if not self.patch_card_sender:
+            return
+
+        if not isinstance(self.patch_card_sender, ReplyNotificationSender):
+            return
+
+        payload = {
+            "reply_author": reply_message.author_email or reply_message.author,
+            "reply_subject": reply_message.subject or "",
+            "reply_url": reply_message.url,
+            "reply_subsystem": reply_message.subsystem_name or "",
+            "reply_date": (
+                reply_message.received_at.strftime("%Y-%m-%d %H:%M:%S")
+                if reply_message.received_at
+                else ""
+            ),
+            "root_subject": root_patch.subject or "",
+            "root_url": root_patch.url,
+        }
+        await self.patch_card_sender.send_reply_notification(payload)
+
+    async def _resolve_patch_feed_message_for_reply(
+        self, session: AsyncSession, reply_message: FeedMessageData
+    ) -> Optional[FeedMessageData]:
+        """解析 Reply 对应的 Patch feed_message（Cover Letter 或 Single Patch）"""
+        if not reply_message.in_reply_to_header:
+            return None
+
+        feed_message_repo = FeedMessageRepository(session)
+        from .thread_service import _extract_message_id_from_header
+
+        async def find_patch_in_chain(
+            message_id_header: str,
+        ) -> Optional[FeedMessageData]:
+            current_raw = message_id_header
+            visited: set[str] = set()
+            depth = 0
+
+            while current_raw and depth < 30:
+                current_id = _extract_message_id_from_header(current_raw)
+                if not current_id or current_id in visited:
+                    break
+                visited.add(current_id)
+
+                msg = await feed_message_repo.find_by_message_id_header(current_id)
+                if not msg:
+                    return None
+
+                if msg.is_patch and not msg.is_reply:
+                    if (
+                        msg.is_series_patch
+                        and not msg.is_cover_letter
+                        and msg.series_message_id
+                    ):
+                        cover = await feed_message_repo.find_by_message_id_header(
+                            msg.series_message_id
+                        )
+                        if cover and cover.is_patch and not cover.is_reply:
+                            return cover
+                    return msg
+
+                current_raw = msg.in_reply_to_header
+                depth += 1
+            return None
+
+        parent = await feed_message_repo.find_by_message_id_header(
+            _extract_message_id_from_header(reply_message.in_reply_to_header)
+            or reply_message.in_reply_to_header
+        )
+
+        # 优先沿 in-reply-to 链找到真正的 PATCH
+        resolved = await find_patch_in_chain(reply_message.in_reply_to_header)
+        if resolved:
+            return resolved
+
+        # 回复到 REPLY：尝试通过 series_message_id 找到根 PATCH
+        series_id = reply_message.series_message_id or (
+            parent.series_message_id if parent else None
+        )
+        if series_id:
+            root = await feed_message_repo.find_by_message_id_header(series_id)
+            if root and root.is_patch and not root.is_reply:
+                return root
+
+        return None
+
+    async def _find_patch_card_for_feed_message(
+        self, patch_card_service: PatchCardService, patch_message: FeedMessageData
+    ) -> Optional[PatchCard]:
+        """根据 Patch feed_message 查找 PatchCard"""
+        patch_card = await patch_card_service.find_by_message_id_header(
+            patch_message.message_id_header
+        )
+        if patch_card:
+            return patch_card
+        if patch_message.series_message_id:
+            return await patch_card_service.find_series_patch_card(
+                patch_message.series_message_id
+            )
+        return None
+
+    async def _auto_watch_patch_card(
+        self, session: AsyncSession, patch_card: PatchCard
+    ) -> None:
+        """自动创建 Thread 并标记 watch 状态"""
+        if not self.thread_sender:
+            logger.debug("Thread sender not configured, skip auto watch")
+            return
+
+        if not patch_card.platform_message_id:
+            logger.warning(
+                "Patch card has no platform_message_id, cannot create thread: %s",
+                patch_card.message_id_header,
+            )
+            return
+
+        from .helpers import create_repositories_and_services
+
+        (_, _, _, patch_card_service, thread_service) = (
+            create_repositories_and_services(session)
+        )
+
+        existing_thread = await thread_service.find_by_message_id_header(
+            patch_card.message_id_header
+        )
+        if existing_thread and existing_thread.is_active:
+            if not patch_card.has_thread:
+                await patch_card_service.mark_as_has_thread(
+                    patch_card.message_id_header
+                )
+            return
+
+        # 刷新 session，确保刚创建的 patch_card 在同一个 session 中可见
+        await session.flush()
+
+        # 使用同一个 session 的 patch_card_service，确保能看到刚创建的 patch_card
+        overview_data = await thread_service.prepare_thread_overview_data(
+            patch_card.message_id_header, patch_card_service=patch_card_service
+        )
+        if not overview_data:
+            logger.warning(
+                "Failed to prepare thread overview data for auto watch: %s",
+                patch_card.message_id_header,
+            )
+            return
+
+        thread_name = patch_card.subject[:100]
+        thread_id, sub_patch_messages = (
+            await self.thread_sender.create_thread_and_send_overview(
+                thread_name, patch_card.platform_message_id, overview_data
+            )
+        )
+
+        if not thread_id:
+            logger.warning(
+                "Failed to create thread for auto watch: %s",
+                patch_card.message_id_header,
+            )
+            return
+
+        await thread_service.create(
+            patch_card.message_id_header,
+            thread_id,
+            thread_name,
+        )
+        if sub_patch_messages:
+            await thread_service.update_sub_patch_messages(
+                thread_id, sub_patch_messages
+            )
+
+        await patch_card_service.mark_as_has_thread(patch_card.message_id_header)
+
     async def _send_thread_update_notification(
         self, thread: PatchThread, patch_card: PatchCard
     ):
@@ -528,41 +852,37 @@ class FeedMessageService:
                 )
                 return
 
-            sub_patch_messages = thread.sub_patch_messages or {}
-            message_id = sub_patch_messages.get(target_patch_index)
+            message_id = self._get_thread_overview_message_id(thread)
 
             if not message_id:
                 logger.warning(
-                    "No message_id found for patch %s in thread %s",
-                    target_patch_index,
+                    "No overview message_id found for thread %s",
                     thread.thread_id,
                 )
                 return
 
-            sub_overview = await self._prepare_patch_overview_data(
-                session, target_patch
+            overview_data = await self._prepare_thread_overview_data(
+                session, patch_card.message_id_header
             )
 
-            if not sub_overview:
+            if not overview_data:
                 return
 
             success = await self.thread_sender.update_thread_overview(
                 thread.thread_id,
                 message_id,
-                sub_overview,
+                overview_data,
             )
 
             if success:
                 logger.info(
-                    "Updated patch [%s] message in thread %s",
-                    target_patch_index,
+                    "Updated thread overview message in thread %s",
                     thread.thread_id,
                 )
                 await self._send_thread_update_notification(thread, patch_card)
             else:
                 logger.warning(
-                    "Failed to update patch [%s] message in thread %s",
-                    target_patch_index,
+                    "Failed to update thread overview message in thread %s",
                     thread.thread_id,
                 )
         except (RuntimeError, ValueError, AttributeError) as e:
@@ -591,22 +911,20 @@ class FeedMessageService:
                 )
                 return
 
-            sub_patch_messages = thread.sub_patch_messages or {}
-            message_id = sub_patch_messages.get(target_patch_index)
+            message_id = self._get_thread_overview_message_id(thread)
 
             if not message_id:
                 logger.warning(
-                    "No message_id found for patch %s in thread %s",
-                    target_patch_index,
+                    "No overview message_id found for thread %s",
                     thread.thread_id,
                 )
                 return
 
-            sub_overview = await self._prepare_patch_overview_data(
-                session, target_patch
+            overview_data = await self._prepare_thread_overview_data(
+                session, patch_card.message_id_header
             )
 
-            if not sub_overview:
+            if not overview_data:
                 return
 
             successes: list[bool] = []
@@ -615,7 +933,7 @@ class FeedMessageService:
                     result = await renderer.update_sub_patch_message(
                         thread.thread_id,
                         message_id,
-                        sub_overview,
+                        overview_data,
                     )
                     successes.append(bool(result))
                 except (RuntimeError, ValueError, AttributeError) as e:
@@ -630,15 +948,13 @@ class FeedMessageService:
 
             if any(successes):
                 logger.info(
-                    "Updated patch [%s] message in thread %s",
-                    target_patch_index,
+                    "Updated thread overview message in thread %s",
                     thread.thread_id,
                 )
                 await self._send_thread_update_notification(thread, patch_card)
             else:
                 logger.warning(
-                    "Failed to update patch [%s] message in thread %s",
-                    target_patch_index,
+                    "Failed to update thread overview message in thread %s",
                     thread.thread_id,
                 )
         except (RuntimeError, ValueError, AttributeError) as e:
@@ -668,12 +984,15 @@ class FeedMessageService:
         if not in_reply_to:
             return None, None
 
+        target_patch = None
+        target_patch_index = None
+
         # 单 Patch：直接匹配
         if not patch_card.is_series_patch:
             if patch_card.message_id_header in in_reply_to:
-                single_patch = build_single_patch_info(patch_card)
-                return single_patch, 1
-            return None, None
+                target_patch = build_single_patch_info(patch_card)
+                target_patch_index = 1
+            return target_patch, target_patch_index
 
         # Series Patch：首先检查是否回复 Cover Letter
         if patch_card.message_id_header in in_reply_to:
@@ -681,22 +1000,26 @@ class FeedMessageService:
             if patch_card.series_patches:
                 for patch in patch_card.series_patches:
                     if patch.patch_index == 0:  # Cover Letter
-                        return patch, 0
+                        target_patch = patch
+                        target_patch_index = 0
+                        break
             # 如果找不到 Cover Letter 的 patch，使用 patch_card 构建一个
             # 这种情况不应该发生，但为了健壮性，我们处理它
-            logger.warning(
-                f"Cover Letter patch not found in series_patches for {patch_card.message_id_header}, "
-                f"using patch_card to build patch info"
-            )
-            from .types import SeriesPatchInfo
-            cover_patch = SeriesPatchInfo(
-                subject=patch_card.subject,
-                patch_index=0,
-                patch_total=patch_card.patch_total or 1,
-                message_id=patch_card.message_id_header,
-                url=patch_card.url or "",
-            )
-            return cover_patch, 0
+            if not target_patch:
+                logger.warning(
+                    f"Cover Letter patch not found in series_patches for {patch_card.message_id_header}, "
+                    f"using patch_card to build patch info"
+                )
+                target_patch = SeriesPatchInfo(
+                    subject=patch_card.subject,
+                    patch_index=0,
+                    patch_total=patch_card.patch_total or 1,
+                    message_id=patch_card.message_id_header,
+                    url=patch_card.url or "",
+                )
+                target_patch_index = 0
+
+            return target_patch, target_patch_index
 
         # Series Patch：查找匹配的子 Patch
         if patch_card.series_patches:
@@ -704,22 +1027,24 @@ class FeedMessageService:
                 if patch.patch_index == 0:  # 跳过 Cover Letter
                     continue
                 if patch.message_id and patch.message_id in in_reply_to:
-                    return patch, patch.patch_index
+                    target_patch = patch
+                    target_patch_index = patch.patch_index
+                    break
 
-        return None, None
+        return target_patch, target_patch_index
 
-    async def _prepare_patch_overview_data(self, session: AsyncSession, target_patch):
-        """准备 Patch 的 overview 数据
+    def _get_thread_overview_message_id(self, thread: PatchThread) -> Optional[str]:
+        """获取 Thread Overview 的消息 ID。"""
+        sub_patch_messages = thread.sub_patch_messages or {}
+        if sub_patch_messages:
+            return next(iter(sub_patch_messages.values()))
+        return None
 
-        Args:
-            session: 数据库会话
-            target_patch: 目标 Patch 对象
-
-        Returns:
-            SubPatchOverviewData 对象，失败返回 None
-        """
+    async def _prepare_thread_overview_data(
+        self, session: AsyncSession, message_id_header: str
+    ) -> Optional[ThreadOverviewData]:
+        """准备 Thread Overview 数据（用于更新单条概览消息）。"""
         from .helpers import create_repositories_and_services
-        from .types import SubPatchOverviewData
 
         try:
             (
@@ -729,23 +1054,10 @@ class FeedMessageService:
                 _,
                 thread_service,
             ) = create_repositories_and_services(session)
-
-            patch_replies = await thread_service.get_all_replies_for_patch(
-                target_patch.message_id
-            )
-
-            patch_reply_hierarchy = await thread_service.build_reply_hierarchy(
-                patch_replies, target_patch.message_id
-            )
-
-            return SubPatchOverviewData(
-                patch=target_patch,
-                replies=patch_replies,
-                reply_hierarchy=patch_reply_hierarchy,
-            )
+            return await thread_service.prepare_thread_overview_data(message_id_header)
         except (RuntimeError, ValueError, AttributeError) as e:
             logger.error(
-                f"Failed to prepare patch overview data: {e}",
+                f"Failed to prepare thread overview data: {e}",
                 exc_info=True,
             )
             return None

--- a/src/plugins/lkml_bot/adapters/__init__.py
+++ b/src/plugins/lkml_bot/adapters/__init__.py
@@ -3,10 +3,4 @@
 from .discord_adapter import DiscordAdapter
 from .message_adapter import MessageAdapter
 
-# 导出兼容性适配器（如果可用）
-try:
-    from .discord_compat_adapter import CompatibleDiscordAdapter
-
-    __all__ = ["DiscordAdapter", "MessageAdapter", "CompatibleDiscordAdapter"]
-except ImportError:
-    __all__ = ["DiscordAdapter", "MessageAdapter"]
+__all__ = ["DiscordAdapter", "MessageAdapter"]

--- a/src/plugins/lkml_bot/client/discord_channel.py
+++ b/src/plugins/lkml_bot/client/discord_channel.py
@@ -1,0 +1,115 @@
+"""Discord 频道消息发送工具"""
+
+import asyncio
+from typing import Optional
+
+import httpx
+from nonebot.log import logger
+
+from .discord_client import truncate_description
+
+
+def _build_channel_headers(config) -> dict:
+    """构建 Discord 请求头"""
+    return {
+        "Authorization": f"Bot {config.discord_bot_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _build_channel_url(config) -> str:
+    """构建 Discord 频道发送 URL"""
+    return f"https://discord.com/api/v10/channels/{config.platform_channel_id}/messages"
+
+
+async def _post_embed_with_retries(
+    url_path: str, headers: dict, embed: dict, max_retries: int
+) -> Optional[str]:
+    """发送 embed 请求并处理重试"""
+    result_message_id: Optional[str] = None
+    for attempt in range(max_retries):
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url_path,
+                    json={"embeds": [embed]},
+                    headers=headers,
+                    timeout=30.0,
+                )
+
+                if response.status_code in {200, 201}:
+                    result = response.json()
+                    result_message_id = result.get("id")
+                    break
+
+                if response.status_code == 429:
+                    retry_after = response.json().get("retry_after", 1.0)
+                    logger.warning(
+                        "Discord rate limit hit (429), retry after %ss "
+                        "(attempt %d/%d)",
+                        retry_after,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    if attempt < max_retries - 1:
+                        await asyncio.sleep(retry_after)
+                        continue
+                    break
+
+                logger.error(
+                    "Failed to send embed to channel: %s, %s",
+                    response.status_code,
+                    response.text,
+                )
+                break
+            except httpx.TimeoutException:
+                logger.error("Timeout sending Discord channel embed")
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1)
+                    continue
+                break
+            except (httpx.HTTPError, RuntimeError) as e:
+                logger.error(
+                    "Error sending Discord channel embed: %s", e, exc_info=True
+                )
+                break
+
+    return result_message_id
+
+
+def _build_channel_embed(
+    title: str, description: str, url: Optional[str], color: Optional[int]
+) -> dict:
+    """构建 Discord embed 数据"""
+    embed = {
+        "title": title[:256],
+        "description": truncate_description(description),
+        "color": color if color is not None else 0x5865F2,
+    }
+    if url:
+        embed["url"] = url
+    return embed
+
+
+async def send_channel_embed(
+    config,
+    title: str,
+    description: str,
+    url: Optional[str] = None,
+    color: Optional[int] = None,
+    max_retries: int = 3,
+) -> Optional[str]:
+    """发送 embed 消息到频道（带 rate limit 处理）"""
+    try:
+        if not config.discord_bot_token or not config.platform_channel_id:
+            logger.error("Discord bot token or channel ID not configured")
+            return None
+
+        headers = _build_channel_headers(config)
+        embed = _build_channel_embed(title, description, url, color)
+        url_path = _build_channel_url(config)
+
+        return await _post_embed_with_retries(url_path, headers, embed, max_retries)
+    except (ValueError, KeyError) as e:
+        logger.error("Data error sending Discord channel embed: %s", e, exc_info=True)
+        return None

--- a/src/plugins/lkml_bot/multi_platform_thread_sender.py
+++ b/src/plugins/lkml_bot/multi_platform_thread_sender.py
@@ -12,7 +12,7 @@ from typing import Dict, Optional, Tuple
 
 from nonebot.log import logger
 
-from lkml.service.types import SubPatchOverviewData, ThreadOverviewData
+from lkml.service.types import ThreadOverviewData
 
 from .client.discord_client import DiscordClient
 from .client.feishu_client import FeishuClient
@@ -99,14 +99,14 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         self,
         thread_id: str,
         message_id: str,
-        sub_overview: SubPatchOverviewData,
+        overview_data: ThreadOverviewData,
     ) -> bool:
         """更新 Thread Overview
 
         Args:
             thread_id: Discord Thread ID
             message_id: 要更新的消息 ID
-            sub_overview: 子 PATCH Overview 数据
+            overview_data: Thread Overview 数据
 
         Returns:
             成功返回 True，失败返回 False
@@ -115,7 +115,9 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
 
         # 1) Discord：更新 Thread 消息
         try:
-            discord_rendered = self.discord_renderer.render_sub_patch(sub_overview)
+            discord_rendered = self.discord_renderer.render_overview_message(
+                overview_data
+            )
             success = await self.discord_client.update_thread_overview(
                 thread_id, message_id, discord_rendered
             )
@@ -131,7 +133,7 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         # 2) Feishu：发送 Thread 更新通知卡片
         try:
             feishu_rendered = self.feishu_renderer.render_update_notification(
-                sub_overview
+                overview_data
             )
             await self.feishu_client.update_thread_overview("", "", feishu_rendered)
         except Exception as e:  # pylint: disable=broad-except

--- a/src/plugins/lkml_bot/renders/patch_card/feishu_render.py
+++ b/src/plugins/lkml_bot/renders/patch_card/feishu_render.py
@@ -185,3 +185,173 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
             subpatch_lines.append(f"  - [{subject}]({link}) ")
 
         return "\n".join(subpatch_lines), len(patch_card.series_patches)
+
+    def render_reply_notification(self, payload: dict):
+        """渲染 Reply 通知为 Feishu 卡片（不发送）
+
+        Args:
+            payload: Reply 通知数据
+                - reply_author: 回复作者
+                - reply_subject: 回复主题
+                - reply_url: 回复链接
+                - root_subject: 根 Patch 主题
+                - root_url: 根 Patch 链接
+
+        Returns:
+            FeishuRenderedReplyNotification 渲染结果
+        """
+        from ..types import FeishuRenderedReplyNotification
+
+        reply_author = payload.get("reply_author") or "unknown"
+        reply_subject = payload.get("reply_subject") or ""
+        reply_url = payload.get("reply_url")
+
+        # 标题（使用 subject 名称，可点击链接）
+        if reply_subject and reply_url:
+            header_title = f"[{reply_subject}]({reply_url})"
+        elif reply_subject:
+            header_title = reply_subject
+        else:
+            header_title = f"[Reply from {reply_author}]"
+
+        base_content = self._build_reply_base_content(payload, reply_author)
+        elements = self._build_reply_elements(payload, base_content)
+        card = self._build_reply_card(header_title, elements)
+
+        return FeishuRenderedReplyNotification(card=card)
+
+    def _build_reply_base_content(self, payload: dict, reply_author: str) -> str:
+        """构建 Reply 通知的基础信息内容"""
+        reply_subsystem = payload.get("reply_subsystem") or ""
+        reply_date = payload.get("reply_date") or ""
+
+        base_content_lines = []
+        if reply_subsystem:
+            base_content_lines.append(f"• **Subsystem** ：{reply_subsystem}")
+        if reply_date:
+            base_content_lines.append(f"• **Date** ：{reply_date}")
+        base_content_lines.append(f"• **Author** ：{reply_author}")
+
+        return "\n".join(base_content_lines)
+
+    def _build_reply_elements(self, payload: dict, base_content: str) -> list:
+        """构建 Reply 通知的卡片元素列表"""
+        reply_subject = payload.get("reply_subject") or ""
+        reply_url = payload.get("reply_url")
+        root_subject = payload.get("root_subject") or ""
+        root_url = payload.get("root_url")
+
+        elements = [
+            {
+                "tag": "column_set",
+                "flex_mode": "stretch",
+                "horizontal_spacing": "8px",
+                "horizontal_align": "left",
+                "columns": [
+                    {
+                        "tag": "column",
+                        "width": "weighted",
+                        "background_style": "grey-50",
+                        "elements": [
+                            {
+                                "tag": "markdown",
+                                "content": base_content,
+                                "text_align": "left",
+                                "text_size": "normal",
+                            }
+                        ],
+                        "padding": "12px 12px 12px 12px",
+                        "vertical_spacing": "8px",
+                        "horizontal_align": "left",
+                        "vertical_align": "top",
+                        "weight": 1,
+                    }
+                ],
+                "margin": "0px 0px 0px 0px",
+            }
+        ]
+
+        # Reply Subject 和 Root Patch 显示在单独的区域
+        if reply_subject:
+            reply_subject_content = (
+                f"[{reply_subject}]({reply_url})" if reply_url else reply_subject
+            )
+            elements.append(
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": f"**Reply Subject:**\n{reply_subject_content}",
+                    },
+                }
+            )
+
+        if root_subject:
+            root_patch_content = (
+                f"[{root_subject}]({root_url})" if root_url else root_subject
+            )
+            elements.append(
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": f"**Root Patch:**\n{root_patch_content}",
+                    },
+                }
+            )
+
+        # 查看 Reply 按钮
+        if reply_url:
+            elements.append(
+                {
+                    "tag": "button",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "查看 Reply",
+                    },
+                    "type": "primary_filled",
+                    "width": "fill",
+                    "behaviors": [
+                        {
+                            "type": "open_url",
+                            "default_url": reply_url,
+                            "pc_url": "",
+                            "ios_url": "",
+                            "android_url": "",
+                        }
+                    ],
+                    "margin": "4px 0px 4px 0px",
+                }
+            )
+
+        return elements
+
+    def _build_reply_card(self, header_title: str, elements: list) -> dict:
+        """构建 Reply 通知的完整卡片结构"""
+        return {
+            "msg_type": "interactive",
+            "card": {
+                "schema": "2.0",
+                "config": {"update_multi": True},
+                "header": {
+                    "title": {
+                        "tag": "lark_md",
+                        "content": header_title,
+                    },
+                    "subtitle": {"tag": "plain_text", "content": ""},
+                    "text_tag_list": [
+                        {
+                            "tag": "text_tag",
+                            "text": {"tag": "plain_text", "content": "Reply 通知"},
+                            "color": "blue",
+                        }
+                    ],
+                    "template": "blue",
+                    "padding": "12px 8px 12px 8px",
+                },
+                "body": {
+                    "direction": "vertical",
+                    "elements": elements,
+                },
+            },
+        }

--- a/src/plugins/lkml_bot/renders/patch_card/renderer.py
+++ b/src/plugins/lkml_bot/renders/patch_card/renderer.py
@@ -124,3 +124,67 @@ class PatchCardRenderer:
         lines.append("```")
 
         return "\n".join(lines)
+
+    def render_reply_notification(self, payload: dict):
+        """渲染 Reply 通知为 Discord 格式（不发送）
+
+        Args:
+            payload: Reply 通知数据
+                - reply_author: 回复作者
+                - reply_subject: 回复主题
+                - reply_url: 回复链接
+                - root_subject: 根 Patch 主题
+                - root_url: 根 Patch 链接
+
+        Returns:
+            DiscordRenderedReplyNotification 渲染结果
+        """
+        from ..types import DiscordRenderedReplyNotification
+
+        reply_author = payload.get("reply_author") or "unknown"
+        reply_subject = payload.get("reply_subject") or ""
+        reply_url = payload.get("reply_url")
+        reply_subsystem = payload.get("reply_subsystem") or ""
+        reply_date = payload.get("reply_date") or ""
+        root_subject = payload.get("root_subject") or ""
+        root_url = payload.get("root_url")
+
+        # 标题（使用 subject 名称，可点击链接）
+        if reply_subject:
+            title = reply_subject
+        else:
+            title = f"[Reply from {reply_author}]"
+
+        lines = []
+
+        # 信息框（YAML 格式，只显示 Subsystem、Date、Author - 都是 reply 的信息）
+        lines.append("```yaml")
+        if reply_subsystem:
+            lines.append(f"Subsystem: {reply_subsystem}")
+        if reply_date:
+            lines.append(f"Date: {reply_date}")
+        lines.append(f"Author: {reply_author}")
+        lines.append("```")
+
+        # Reply Subject 和 Root Patch 显示在 YAML 模块外（换行显示）
+        if reply_subject:
+            lines.append("Reply Subject:")
+            if reply_url:
+                lines.append(f"[{reply_subject}]({reply_url})")
+            else:
+                lines.append(reply_subject)
+        if root_subject:
+            lines.append("Root Patch:")
+            if root_url:
+                lines.append(f"[{root_subject}]({root_url})")
+            else:
+                lines.append(root_subject)
+
+        description = "\n".join(lines)
+
+        return DiscordRenderedReplyNotification(
+            title=title,
+            description=description,
+            url=reply_url,
+            embed_color=0x5865F2,  # 蓝色（参考第一张图）
+        )

--- a/src/plugins/lkml_bot/renders/thread/feishu_render.py
+++ b/src/plugins/lkml_bot/renders/thread/feishu_render.py
@@ -4,7 +4,7 @@
 发送由客户端负责。
 """
 
-from lkml.service.types import SubPatchOverviewData, ThreadOverviewData
+from lkml.service.types import ThreadOverviewData
 
 from ..types import FeishuRenderedThreadNotification
 
@@ -118,18 +118,18 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
         return FeishuRenderedThreadNotification(card=card)
 
     def render_update_notification(
-        self, sub_overview: SubPatchOverviewData
+        self, overview_data: ThreadOverviewData
     ) -> FeishuRenderedThreadNotification:
         """渲染 Thread 更新通知卡片（不发送）
 
         Args:
-            sub_overview: 子补丁概览数据
+            overview_data: 线程概览数据
 
         Returns:
             FeishuRenderedThreadNotification 渲染结果
         """
-        subj = sub_overview.patch.subject[:200]
-        link = sub_overview.patch.url or ""
+        subj = overview_data.patch_card.subject[:200]
+        link = overview_data.patch_card.url or ""
 
         card = {
             "msg_type": "interactive",

--- a/src/plugins/lkml_bot/renders/thread/renderer.py
+++ b/src/plugins/lkml_bot/renders/thread/renderer.py
@@ -58,17 +58,8 @@ class ThreadOverviewRenderer:
 
         # 使用 service 层准备好的 sub_patch_overviews
         if overview_data.sub_patch_overviews:
-            for sub_overview in overview_data.sub_patch_overviews:
-                patch = sub_overview.patch
-                patch_index = patch.patch_index
-
-                # 渲染子 PATCH 消息
-                patch_content = self._render_sub_patch(sub_overview)
-                patch_content += "\n\n---\n"
-
-                messages[patch_index] = DiscordRenderedThreadMessage(
-                    content=patch_content, embed=None
-                )
+            content = self.render_overview_message(overview_data).content
+            messages[0] = DiscordRenderedThreadMessage(content=content, embed=None)
 
         return DiscordRenderedThreadOverview(messages=messages)
 
@@ -84,7 +75,13 @@ class ThreadOverviewRenderer:
             DiscordRenderedThreadMessage 渲染结果
         """
         content = self._render_sub_patch(sub_overview)
-        content += "\n\n---\n"
+        return DiscordRenderedThreadMessage(content=content, embed=None)
+
+    def render_overview_message(
+        self, overview_data: ThreadOverviewData
+    ) -> DiscordRenderedThreadMessage:
+        """渲染 Thread Overview 为单条消息（用于更新）"""
+        content = self._render_overview_content(overview_data)
         return DiscordRenderedThreadMessage(content=content, embed=None)
 
     def _render_sub_patch(self, sub_overview: SubPatchOverviewData) -> str:
@@ -127,6 +124,17 @@ class ThreadOverviewRenderer:
             lines.append("_(No replies)_")
 
         return "\n".join(lines)
+
+    def _render_overview_content(self, overview_data: ThreadOverviewData) -> str:
+        """渲染所有子 PATCH 概览为单条消息内容"""
+        if not overview_data.sub_patch_overviews:
+            return ""
+
+        blocks = [
+            self._render_sub_patch(sub_overview)
+            for sub_overview in overview_data.sub_patch_overviews
+        ]
+        return "\n".join(blocks)
 
     def _format_reply_tree(
         self, reply: FeedMessage, reply_map: Dict[str, ReplyMapEntry], level: int

--- a/src/plugins/lkml_bot/renders/types.py
+++ b/src/plugins/lkml_bot/renders/types.py
@@ -46,3 +46,20 @@ class FeishuRenderedThreadNotification:
     """Feishu Thread 通知卡片渲染结果"""
 
     card: Dict  # Feishu 卡片 JSON
+
+
+@dataclass
+class DiscordRenderedReplyNotification:
+    """Discord Reply 通知渲染结果"""
+
+    title: str
+    description: str
+    url: Optional[str] = None
+    embed_color: int = 0x5865F2  # 默认蓝色
+
+
+@dataclass
+class FeishuRenderedReplyNotification:
+    """Feishu Reply 通知渲染结果"""
+
+    card: Dict  # Feishu 卡片 JSON


### PR DESCRIPTION
# Feature: Reply-Driven Patch Card Auto-Watch with Filter-Based Gating

Closes #14

## Summary

This PR enhances reply handling so that replies can trigger patch card creation and auto-watch only when filter rules are matched, while preserving existing thread update behavior. It also fixes CC parsing and avoids loading plugin adapters during compat adapter registration.

## Key Changes

### Reply Perspective Processing

- **Resolve replies back to the root patch**: Replies are now resolved to their root patch (cover letter or single patch) by traversing the `in_reply_to` chain
- **Avoid creating Re:-titled cards**: The system anchors on the original PATCH instead of creating cards with "Re:" prefixed subjects
- **Apply filter matching based on reply content**: Filter rules are evaluated using the reply message as the matching subject (reply is the matching主体), not the original patch
- **Cover letter handling**: Replies to cover letters are properly mapped to the series cover patch, with fallback warnings when missing

### Auto-Watch Logic

- **If patch card exists but not watched** → automatically create Thread (watch)
- **If patch card doesn't exist** → create patch card and auto-watch (only if filters match)
- **If already watched** → keep current behavior (thread updates only)
- **Filter-gated auto-watch**: Auto-watch is only enabled when:
  - Reply matches at least one filter rule
  - Global auto-watch feature is enabled

### Filter Enforcement

- **No match, no auto-watch**: If no filter rules match, no auto-watch occurs (regardless of exclusive mode)
- **Reply perspective requires matched filters**: Reply-driven patch card creation and auto-watch require explicit rule match (no implicit allow)
- **Filter evaluation context**: Filters are evaluated using reply message content (author, subject, subsystem, keywords, CC list) while patch card creation uses the original patch data

### CC Fetcher Fix

- **Preserve email addresses**: When stripping HTML tags from CC list, email addresses in `<email@domain>` format are now preserved before HTML tag removal
- **Improved parsing**: Enhanced regex pattern to extract emails before HTML cleanup to avoid losing email addresses during tag stripping

### Compat Adapter Import Fix

- **Move compat adapter under `src/compat`**: Discord compatibility adapter moved from `src/plugins/lkml_bot/adapters/` to `src/compat/` to avoid plugin package imports during bootstrap
- **Avoid plugin import during registration**: Prevents double-registration of commands and plugin initialization issues during adapter registration

## Technical Details

### Reply Resolution Flow

1. Extract `in_reply_to_header` from reply message
2. Traverse the reply chain up to 30 levels deep
3. Find the first non-reply patch message
4. If found patch is a series sub-patch, resolve to its cover letter
5. Return the root patch (cover letter or single patch)

### Filter Matching for Replies

1. Convert reply message to `ServiceFeedMessage` format
2. Apply all enabled filter rules using reply content
3. If no rules match → return early (no processing)
4. If rules match → proceed with patch card creation/auto-watch using original patch data

### Auto-Watch Decision Tree

```
Reply received
  ↓
Resolve to root patch
  ↓
Apply filters (using reply content)
  ↓
No match? → Exit
  ↓
Match found? → Continue
  ↓
Patch card exists?
  ├─ Yes, has_thread? → Exit (already watched)
  ├─ Yes, no thread? → Auto-watch
  └─ No → Create patch card → Auto-watch
```

## Files Changed

- `src/lkml/service/feed_message_service.py`: Core reply processing logic, filter matching, auto-watch
- `src/lkml/feed/cc_fetcher.py`: CC parsing fix to preserve email addresses
- `src/lkml/service/thread_service.py`: Minor updates for reply handling
- `src/compat/discord_compat_adapter.py`: Moved from plugins directory
- `bot.py`: Updated import path for compat adapter
- `src/plugins/lkml_bot/`: Various renderer and client updates for reply notifications

## Commits

- `2c813b5` - feat: handle reply-driven patch card auto-watch
- `fcd5846` - fix: preserve email addresses when stripping HTML
- `dc840e8` - fix: return cover letter patch on reply
- `35eda91` - fix: avoid plugin import when registering compat adapter
