### PR TITLE
fix: remove early break in feed entry filtering 

### DIFF
--- a/src/lkml/feed/feed.py
+++ b/src/lkml/feed/feed.py
@@ -133,8 +133,8 @@ class FeedProcessor:
 
             if entry_dt > self.last_update_dt:
                 entries.append(entry)
-            else:
-                break
+            # 不使用 break，继续检查所有条目
+            # lore.kernel.org 的 feed 不保证严格按时间递减排序
         return entries
 
     def get_feed_entries(self, feed_url: str) -> List[FeedParserDict]:


### PR DESCRIPTION
## Summary                                                                                                                                                               
                                                                                                                                                                           
  - Fix message loss during feed collection caused by early `break` in `_filter_entries_by_date`                                                                           
  - The function incorrectly assumed lore.kernel.org Atom feed is strictly sorted in descending chronological order                                                        
                                                                                                                                                                           
  ## Problem                                                                                                                                                               
                                                                                                                                                                           
  When feed returns entries in non-strictly descending order:                                                                                                              
                                                                                                                                                                           
  [15:08 new message]                                                                                                                                                      
  [14:19 old message]  <- break triggered                                                                                                                                  
  [14:54 new message]  <- skipped!                                                                                                                                         
  [14:42 new message]  <- skipped!                                                                                                                                         
                                                                                                                                                                           
  This caused ~49 minutes of messages to be lost in production (e.g., Daniel's and Tao Tang's replies to RISC-V IOMMU patches).                                            
                                                                                                                                                                           
  ## Solution                                                                                                                                                              
                                                                                                                                                                           
  Remove the `break` statement to ensure all feed entries are checked regardless of order.                                                                                 
                                                                                                                                                                           
  Closes #20 