### PR TITLE
feat: 春节前大扫除 — filter-first、线程重构、feed 时间戳隔离

### DIFF
--- a/migrations/006_add_summary_to_patch_cards.sql
+++ b/migrations/006_add_summary_to_patch_cards.sql
@@ -1,0 +1,1 @@
+ALTER TABLE patch_cards ADD COLUMN summary TEXT;

--- a/migrations/007_add_summary_to_feed_messages.sql
+++ b/migrations/007_add_summary_to_feed_messages.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feed_messages ADD COLUMN summary TEXT;

--- a/src/lkml/config.py
+++ b/src/lkml/config.py
@@ -101,6 +101,7 @@ class LKMLConfig(BaseModel):
 
     database_url: str = "sqlite+aiosqlite:///./lkml_bot.db"
     manual_subsystems: List[str] = []  # 手动配置的额外子系统
+    gemini_api_key: str = ""  # Gemini API Key（用于内容摘要）
     max_news_count: int = 20
     monitoring_interval: int = 300  # 监控任务执行周期（秒），默认 5 分钟
     # Debug/开发辅助：ISO8601 字符串覆盖 last_update_dt（如 2025-11-03T12:00:00Z）
@@ -225,6 +226,7 @@ class LKMLConfig(BaseModel):
             max(monitoring_interval_raw, 60) if monitoring_interval_raw else None
         )
         last_update_dt_override_iso = cls._get_str_env("LKML_LAST_UPDATE_AT")
+        gemini_api_key = cls._get_str_env("LKML_GEMINI_API_KEY", "")
 
         # 构建配置字典
         config_dict = {"manual_subsystems": manual_subsystems}
@@ -236,5 +238,7 @@ class LKMLConfig(BaseModel):
             config_dict["monitoring_interval"] = monitoring_interval
         if last_update_dt_override_iso is not None:
             config_dict["last_update_dt_override_iso"] = last_update_dt_override_iso
+        if gemini_api_key:
+            config_dict["gemini_api_key"] = gemini_api_key
 
         return cls(**config_dict)

--- a/src/lkml/db/migrations.py
+++ b/src/lkml/db/migrations.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = logging.getLogger(__name__)
@@ -139,7 +140,7 @@ class MigrationRunner:
                     if statement:
                         try:
                             await conn.execute(text(statement))
-                        except (RuntimeError, ValueError) as e:
+                        except (RuntimeError, ValueError, OperationalError) as e:
                             # 某些语句可能因为已存在而失败（如 CREATE INDEX IF NOT EXISTS）
                             # 或者因为不存在而失败（如 DROP COLUMN 时列已不存在）
                             # 检查是否是"已存在"或"不存在"的错误
@@ -160,7 +161,13 @@ class MigrationRunner:
             logger.info(f"Migration {version} applied successfully")
             return True
 
-        except (RuntimeError, ValueError, AttributeError, IOError) as e:
+        except (
+            RuntimeError,
+            ValueError,
+            AttributeError,
+            IOError,
+            OperationalError,
+        ) as e:
             logger.error(f"Failed to execute migration {version}: {e}", exc_info=True)
             return False
 

--- a/src/lkml/db/models.py
+++ b/src/lkml/db/models.py
@@ -79,6 +79,8 @@ class FeedMessageModel(Base):  # pylint: disable=too-few-public-methods
     # 系列 PATCH 的根 message_id（用于关联系列中的 PATCH）
     series_message_id = Column(String(500), nullable=True, index=True)
 
+    summary = Column(Text, nullable=True)  # AI 生成的一句话摘要
+
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
@@ -146,6 +148,7 @@ class PatchCardModel(Base):  # pylint: disable=too-few-public-methods
     to_cc_list = Column(
         JSON, nullable=True
     )  # To 和 CC 列表（从 root patch 抓取，JSON 格式存储邮箱列表，合并去重）
+    summary = Column(Text, nullable=True)  # AI 生成的一句话摘要
 
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
     expires_at = Column(DateTime, nullable=False, index=True)  # 过期时间（24小时后）

--- a/src/lkml/db/repo/feed_message_repository.py
+++ b/src/lkml/db/repo/feed_message_repository.py
@@ -36,6 +36,7 @@ class FeedMessageData:
     patch_total: Optional[int] = None
     is_cover_letter: bool = False
     series_message_id: Optional[str] = None
+    summary: Optional[str] = None  # AI 生成的一句话摘要
     id: Optional[int] = None  # 数据库 ID（Repository 层内部使用，不暴露给上层）
 
 
@@ -80,6 +81,7 @@ class FeedMessageRepository:
             patch_total=model.patch_total,
             is_cover_letter=model.is_cover_letter,
             series_message_id=model.series_message_id,
+            summary=model.summary,
         )
 
     async def find_by_message_id_header(
@@ -170,6 +172,7 @@ class FeedMessageRepository:
         existing_model.patch_total = data.patch_total
         existing_model.is_cover_letter = data.is_cover_letter
         existing_model.series_message_id = data.series_message_id
+        existing_model.summary = data.summary
         await self.session.flush()
         return self._model_to_data(existing_model)
 
@@ -210,6 +213,30 @@ class FeedMessageRepository:
                     return await self._update_existing_feed_message(data)
             # 如果是其他 IntegrityError，重新抛出
             raise
+
+    async def update_summary(
+        self, message_id_header: str, summary: str
+    ) -> Optional[FeedMessageData]:
+        """更新 Feed 消息的 AI 摘要
+
+        Args:
+            message_id_header: 消息 Message-ID Header
+            summary: AI 生成的摘要
+
+        Returns:
+            更新后的 Feed 消息数据，如果不存在则返回 None
+        """
+        result = await self.session.execute(
+            select(FeedMessageModel).where(
+                FeedMessageModel.message_id_header == message_id_header
+            )
+        )
+        model = result.scalar_one_or_none()
+        if model:
+            model.summary = summary
+            await self.session.flush()
+            return self._model_to_data(model)
+        return None
 
     async def find_by_series_message_id(
         self, series_message_id: str

--- a/src/lkml/db/repo/patch_card_repository.py
+++ b/src/lkml/db/repo/patch_card_repository.py
@@ -36,6 +36,7 @@ class PatchCardData:
     id: Optional[int] = None  # 数据库 ID（Repository 层内部使用，不暴露给上层）
     has_thread: bool = False  # 是否已建立 Thread
     to_cc_list: Optional[list] = None  # To 和 CC 列表（从 root patch 抓取，合并去重）
+    summary: Optional[str] = None  # AI 生成的一句话摘要
 
 
 class PatchCardRepository:  # pylint: disable=too-many-instance-attributes
@@ -76,6 +77,7 @@ class PatchCardRepository:  # pylint: disable=too-many-instance-attributes
             id=model.id,
             has_thread=model.has_thread,
             to_cc_list=model.to_cc_list,
+            summary=model.summary,
         )
 
     async def create(self, data: PatchCardData) -> PatchCardData:
@@ -102,6 +104,7 @@ class PatchCardRepository:  # pylint: disable=too-many-instance-attributes
             patch_index=data.patch_index,
             patch_total=data.patch_total,
             to_cc_list=data.to_cc_list,
+            summary=data.summary,
         )
         self.session.add(patch_card)
         await self.session.flush()

--- a/src/lkml/feed/feed.py
+++ b/src/lkml/feed/feed.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 import feedparser
 from feedparser.util import FeedParserDict
 import logging
-from sqlalchemy.exc import SQLAlchemyError
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +20,6 @@ logger = logging.getLogger(__name__)
 from ..config import get_config
 from ..db.models import Subsystem
 from ..db.repo import SUBSYSTEM_REPO
-from ..db.repo import FeedMessageRepository
-from ..service import FeedMessage
 
 if TYPE_CHECKING:
     from ..db.repo import FeedMessageData
@@ -313,46 +310,25 @@ class FeedProcessor:
         in_reply_to_header = self._extract_in_reply_to_header(entry)
         return (email, received_at, message_id, message_id_header, in_reply_to_header)
 
-    def _convert_repo_to_service_feed_message(
-        self, repo_data: "FeedMessageData"
-    ) -> FeedMessage:
-        """将 Repository 层的 FeedMessageData 转换为 Service 层的 FeedMessage"""
-        from ..service.helpers import extract_common_feed_message_fields
+    def _classify_feed_entry(
+        self, entry: FeedParserDict, subsystem: Subsystem
+    ) -> Tuple["FeedMessageData", object]:
+        """Classify a feed entry without any DB writes.
 
-        common_fields = extract_common_feed_message_fields(repo_data)
-        return FeedMessage(**common_fields)
-
-    async def _save_service_feed_message_to_repo(
-        self, feed_message_repo, service_feed_message_data
-    ):
-        """将 Service 层的 FeedMessage 转换为 Repo 层数据并保存"""
+        Returns:
+            (FeedMessageData, MessageClassification) tuple
+        """
         from ..db.repo import FeedMessageData as RepoFeedMessageData
 
-        from ..service.helpers import extract_common_feed_message_fields
-
-        common_fields = extract_common_feed_message_fields(service_feed_message_data)
-        repo_feed_message_data = RepoFeedMessageData(**common_fields)
-
-        return await feed_message_repo.create_or_update(data=repo_feed_message_data)
-
-    def _build_service_feed_message(  # pylint: disable=too-many-arguments
-        self,
-        entry: FeedParserDict,
-        subsystem: Subsystem,
-        email: str,
-        received_at: datetime,
-        message_id: str,
-        message_id_header: str,
-        in_reply_to_header: str,
-        classification,
-    ) -> FeedMessage:
-        """构建 Service 层的 FeedMessage 对象"""
+        base_data = self._extract_feed_message_data(entry, subsystem)
+        email, received_at, message_id, msg_id_header, in_reply_to = base_data
+        classification = classify_message(entry.title, in_reply_to, msg_id_header)
         patch_info = classification.patch_info
-        return FeedMessage(
+        data = RepoFeedMessageData(
             subsystem_name=subsystem.name,
+            message_id_header=msg_id_header or message_id,
             message_id=message_id,
-            message_id_header=message_id_header or message_id,
-            in_reply_to_header=in_reply_to_header,
+            in_reply_to_header=in_reply_to,
             subject=entry.title,
             author=entry.author,
             author_email=email or "unknown@example.com",
@@ -368,96 +344,7 @@ class FeedProcessor:
             is_cover_letter=patch_info.is_cover_letter if patch_info else False,
             series_message_id=classification.series_message_id,
         )
-
-    async def save_feed_message(
-        self, session, entry: FeedParserDict, subsystem: Subsystem
-    ):
-        """保存 Feed 消息到数据库
-
-        Args:
-            session: 数据库会话
-            entry: Feed 解析条目
-            subsystem: 子系统对象
-
-        Returns:
-            保存的 Feed 消息对象
-        """
-        # 提取基本数据（避免创建过多局部变量，使用聚合对象）
-        base_data = self._extract_feed_message_data(entry, subsystem)
-
-        # 创建 Repository 实例
-        feed_message_repo = FeedMessageRepository(session)
-
-        # 检查是否已存在
-        msg_id_header = base_data[3]
-        if msg_id_header:
-            existing_message_data = await feed_message_repo.find_by_message_id_header(
-                msg_id_header
-            )
-            if existing_message_data:
-                logger.debug(f"Feed message already exists: {msg_id_header}")
-                # 即使消息已存在，也需要分类并附加 _classification，以便后续处理 REPLY
-                classification = classify_message(
-                    subject=entry.title,
-                    in_reply_to_header=base_data[4],
-                    message_id_header=msg_id_header,
-                )
-                converted_message = self._convert_repo_to_service_feed_message(
-                    existing_message_data
-                )
-                # 附加分类信息以便后续处理
-                # pylint: disable=protected-access
-                converted_message._classification = classification  # type: ignore
-                return converted_message
-
-        # 使用标准化的消息分类器判断消息类型
-        classification = classify_message(
-            subject=entry.title,
-            in_reply_to_header=base_data[4],
-            message_id_header=msg_id_header,
-        )
-
-        # 调试日志：记录 Series Patch 的分类信息
-        if classification.is_series_patch and classification.patch_info:
-            logger.debug(
-                f"Series PATCH classified: subject={entry.title[:80]}, "
-                f"patch_index={classification.patch_info.index}/{classification.patch_info.total}, "
-                f"is_cover_letter={classification.patch_info.is_cover_letter}, "
-                f"series_message_id={classification.series_message_id[:50] if classification.series_message_id else None}"  # pylint: disable=line-too-long
-            )
-
-        # 构建 Service 层的 FeedMessage 对象
-        service_feed_message_data = self._build_service_feed_message(
-            entry,
-            subsystem,
-            base_data[0],
-            base_data[1],
-            base_data[2],
-            msg_id_header,
-            base_data[4],
-            classification,
-        )
-
-        # 转换为 repo 层数据并保存
-        feed_message_data = await self._save_service_feed_message_to_repo(
-            feed_message_repo, service_feed_message_data
-        )
-
-        # 回复消息补齐系列 ID
-        try:
-            if feed_message_data.is_reply:
-                await self._backfill_series_message_id_chain(
-                    feed_message_repo, feed_message_data
-                )
-        except (RuntimeError, ValueError, AttributeError, SQLAlchemyError) as e:
-            logger.debug(f"Backfill series_message_id failed: {e}")
-
-        # 将分类结果附加到 feed_message_data 对象（用于后续处理）
-        # pylint: disable=protected-access
-        # _classification is used for internal processing, not part of public API
-        feed_message_data._classification = classification  # type: ignore
-
-        return feed_message_data
+        return data, classification
 
     def _create_feed_entry(self, feed_message_data) -> FeedEntry:
         """创建 FeedEntry 对象
@@ -503,95 +390,37 @@ class FeedProcessor:
         """处理条目并返回统计信息
 
         分两个阶段：
-        1. 先将所有 feed_message 入库
-        2. 再批量处理（创建 Patch Card、处理 Reply）
-
-        这样可以避免 Cover Letter 先到达时，子 PATCH 还未入库的时序问题。
+        1. 在内存中分类所有 feed entry（无 DB 写入）
+        2. 由 service 层决定哪些消息需要持久化
         """
         new_count = 0
         reply_count = 0
         processed_entries: List[FeedEntry] = []
 
-        # 阶段 1: 保存所有 feed_message 到数据库
-        saved_messages = []
+        # Phase 1: Classify all entries in-memory (NO DB writes)
+        classified = []
         for entry in entries:
-            feed_message = await self.save_feed_message(session, entry, subsystem)
-            saved_messages.append((feed_message, entry))
+            data, classification = self._classify_feed_entry(entry, subsystem)
+            classified.append((data, classification))
 
-            # 统计消息类型
-            if feed_message.is_reply:
+        # Phase 2: Service layer decides what to persist
+        for data, classification in classified:
+            if classification.is_reply:
                 reply_count += 1
             else:
                 new_count += 1
 
-        # 阶段 2: 批量处理所有 feed_message
-        for feed_message, entry in saved_messages:
-            # 处理 PATCH 卡片生成和 REPLY 逻辑
-            # 使用附加的分类信息（不存储在模型中）
-            if hasattr(feed_message, "_classification") and self.feed_message_service:
-                # pylint: disable=protected-access
-                # _classification is used for internal processing, not part of public API
-                classification = feed_message._classification  # type: ignore
+            if self.feed_message_service:
                 try:
                     await self.feed_message_service.process_email_message(
-                        session, feed_message, classification
+                        session, data, classification
                     )
                 except (RuntimeError, ValueError, AttributeError) as e:
-                    logger.error(
-                        f"Failed to process feed message: {e}",
-                        exc_info=True,
-                    )
+                    logger.error("Failed to process feed message: %s", e, exc_info=True)
 
-            processed_entries.append(self._create_feed_entry(feed_message))
+            processed_entries.append(self._create_feed_entry(data))
 
         return (new_count, reply_count, processed_entries)
-
-    async def _backfill_series_message_id_chain(
-        self,
-        repo: FeedMessageRepository,
-        current: "FeedMessageData",
-    ) -> Optional[str]:
-        series_id = None
-        chain: list["FeedMessageData"] = []
-        visited: set[str] = set()
-
-        node = current
-        depth = 0
-        while node and node.in_reply_to_header and depth < 50:
-            chain.append(node)
-            visited.add(node.message_id_header)
-            parent = await repo.find_by_message_id_header(node.in_reply_to_header)
-            if not parent:
-                break
-            if parent.series_message_id:
-                series_id = parent.series_message_id
-                chain.append(parent)
-                break
-            node = parent
-            depth += 1
-
-        if not series_id:
-            root = None
-            probe = node
-            depth = 0
-            while probe and probe.in_reply_to_header and depth < 50:
-                root = probe
-                probe = await repo.find_by_message_id_header(probe.in_reply_to_header)
-                depth += 1
-            root = probe or root or current
-            if root:
-                series_id = root.series_message_id or root.message_id_header
-
-        if series_id:
-            for msg in chain:
-                if not msg.series_message_id:
-                    msg.series_message_id = series_id
-                    await repo.create_or_update(data=msg)
-            if not current.series_message_id:
-                current.series_message_id = series_id
-                await repo.create_or_update(data=current)
-            return series_id
-        return None
 
     def _update_last_update_time(self, entries: List[FeedParserDict]) -> None:
         """更新最后更新时间"""

--- a/src/lkml/feed/feed.py
+++ b/src/lkml/feed/feed.py
@@ -52,32 +52,27 @@ class FeedProcessor:
         self.thread_manager = thread_manager
         self.feed_message_service = feed_message_service
 
-        # 初始化 last_update_dt
-        # 优先使用环境变量覆盖（用于调试/开发）
+        # Per-subsystem last_update_dt tracking (fixes shared-timestamp bug)
+        self._last_update_dts: dict[str, datetime] = {}
+
+        # 解析环境变量覆盖（用于调试/开发），作为所有子系统的初始值
+        self._override_dt: Optional[datetime] = None
         cfg = get_config()
         override_iso = getattr(cfg, "last_update_dt_override_iso", None)
         if override_iso is not None:
-            # 使用 ISO8601 字符串覆盖（支持结尾 Z）
             iso_str = str(override_iso).strip()
             try:
                 if iso_str.endswith("Z"):
                     iso_str = iso_str[:-1] + "+00:00"
-                self.last_update_dt = datetime.fromisoformat(iso_str)
-                # 确保为 aware；若解析为 naive，则设为 UTC
-                if self.last_update_dt.tzinfo is None:
-                    self.last_update_dt = self.last_update_dt.replace(
-                        tzinfo=timezone.utc
-                    )
-                logger.info(
-                    f"Using LKML_LAST_UPDATE_AT override: {self.last_update_dt}"
-                )
+                self._override_dt = datetime.fromisoformat(iso_str)
+                if self._override_dt.tzinfo is None:
+                    self._override_dt = self._override_dt.replace(tzinfo=timezone.utc)
+                logger.info(f"Using LKML_LAST_UPDATE_AT override: {self._override_dt}")
             except (ValueError, AttributeError, TypeError):
                 logger.warning(
-                    f"Invalid LKML_LAST_UPDATE_AT format: {override_iso}, using database query"
+                    f"Invalid LKML_LAST_UPDATE_AT format: {override_iso}, "
+                    "using database query"
                 )
-                self.last_update_dt = None  # 标记需要从数据库查询
-        else:
-            self.last_update_dt = None  # 标记需要从数据库查询
 
     def _handle_feed_status(self, feed_status: Optional[int], feed_url: str) -> bool:
         """处理 feed 状态码，返回是否应该继续处理"""
@@ -116,7 +111,7 @@ class FeedProcessor:
         return True
 
     def _filter_entries_by_date(
-        self, feed_entries: List[FeedParserDict]
+        self, feed_entries: List[FeedParserDict], last_update_dt: datetime
     ) -> List[FeedParserDict]:
         """根据日期筛选新条目"""
         entries: List[FeedParserDict] = []
@@ -128,13 +123,15 @@ class FeedProcessor:
                 entries.append(entry)
                 continue
 
-            if entry_dt > self.last_update_dt:
+            if entry_dt > last_update_dt:
                 entries.append(entry)
             # 不使用 break，继续检查所有条目
             # lore.kernel.org 的 feed 不保证严格按时间递减排序
         return entries
 
-    def get_feed_entries(self, feed_url: str) -> List[FeedParserDict]:
+    def get_feed_entries(
+        self, feed_url: str, last_update_dt: datetime
+    ) -> List[FeedParserDict]:
         """拉取并筛选新条目（带指数退避重试）"""
         start_ts = time.time()
         logger.info(f"Fetching feed from {feed_url}")
@@ -167,7 +164,7 @@ class FeedProcessor:
             if not self._handle_feed_bozo(feed, feed_url):
                 return []
 
-            entries = self._filter_entries_by_date(feed.entries)
+            entries = self._filter_entries_by_date(feed.entries, last_update_dt)
 
             if feed.bozo and entries:
                 logger.info(
@@ -422,26 +419,31 @@ class FeedProcessor:
 
         return (new_count, reply_count, processed_entries)
 
-    def _update_last_update_time(self, entries: List[FeedParserDict]) -> None:
-        """更新最后更新时间"""
+    def _update_last_update_time(
+        self, subsystem_name: str, entries: List[FeedParserDict]
+    ) -> None:
+        """更新指定子系统的最后更新时间"""
         if not entries:
             return
         latest_entry = entries[0]
         if hasattr(latest_entry, "updated_parsed") and latest_entry.updated_parsed:
-            self.last_update_dt = datetime(
+            self._last_update_dts[subsystem_name] = datetime(
                 *latest_entry.updated_parsed[:6], tzinfo=timezone.utc
             )
 
     async def _initialize_last_update_dt(self, subsystem_name: str) -> None:
-        """从数据库初始化 last_update_dt
-
-        如果 last_update_dt 为 None，从数据库中查询该子系统最新的 received_at
+        """从数据库初始化指定子系统的 last_update_dt
 
         Args:
             subsystem_name: 子系统名称
         """
-        if self.last_update_dt is not None:
-            return  # 已经初始化（使用环境变量覆盖）
+        if subsystem_name in self._last_update_dts:
+            return  # 该子系统已初始化
+
+        # 环境变量覆盖优先
+        if self._override_dt is not None:
+            self._last_update_dts[subsystem_name] = self._override_dt
+            return
 
         try:
             async with self.database.get_db_session() as session:
@@ -457,30 +459,28 @@ class FeedProcessor:
                 max_received_at = result.scalar()
 
                 if max_received_at:
-                    # 确保为 aware datetime
                     if max_received_at.tzinfo is None:
-                        self.last_update_dt = max_received_at.replace(
+                        self._last_update_dts[subsystem_name] = max_received_at.replace(
                             tzinfo=timezone.utc
                         )
                     else:
-                        self.last_update_dt = max_received_at
+                        self._last_update_dts[subsystem_name] = max_received_at
                     logger.info(
                         f"Initialized last_update_dt from database for {subsystem_name}: "
-                        f"{self.last_update_dt}"
+                        f"{self._last_update_dts[subsystem_name]}"
                     )
                 else:
-                    # 没有历史数据，使用当前时间
-                    self.last_update_dt = datetime.now(timezone.utc)
+                    self._last_update_dts[subsystem_name] = datetime.now(timezone.utc)
                     logger.info(
                         f"No historical data for {subsystem_name}, using current time: "
-                        f"{self.last_update_dt}"
+                        f"{self._last_update_dts[subsystem_name]}"
                     )
         except (RuntimeError, ValueError) as e:
             logger.warning(
-                f"Failed to initialize last_update_dt from database: {e}, "
-                f"using current time"
+                f"Failed to initialize last_update_dt from database for "
+                f"{subsystem_name}: {e}, using current time"
             )
-            self.last_update_dt = datetime.now(timezone.utc)
+            self._last_update_dts[subsystem_name] = datetime.now(timezone.utc)
 
     async def process_feed(
         self, subsystem_name: str, feed_url: str
@@ -496,12 +496,12 @@ class FeedProcessor:
         """
         logger.info(f"Processing feed for subsystem: {subsystem_name}")
 
-        # 初始化 last_update_dt（如果还没有初始化）
+        # 初始化该子系统的 last_update_dt（如果还没有初始化）
         await self._initialize_last_update_dt(subsystem_name)
 
         proc_start = time.time()
 
-        entries = self.get_feed_entries(feed_url)
+        entries = self.get_feed_entries(feed_url, self._last_update_dts[subsystem_name])
         if not entries:
             logger.info(f"No new entries found for {subsystem_name}")
             return FeedProcessResult(
@@ -515,7 +515,7 @@ class FeedProcessor:
             )
             await session.commit()
 
-        self._update_last_update_time(entries)
+        self._update_last_update_time(subsystem_name, entries)
 
         proc_ms = int((time.time() - proc_start) * 1000)
         logger.info(

--- a/src/lkml/feed/thread_backfill.py
+++ b/src/lkml/feed/thread_backfill.py
@@ -1,0 +1,254 @@
+"""Thread backfill from lore.kernel.org
+
+Fetches existing replies for a thread via t.mbox.gz and saves them to the DB,
+so the Thread Overview is complete from the start.
+"""
+
+import email.header
+import email.utils
+import gzip
+import logging
+import mailbox
+import tempfile
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db.repo import FeedMessageData, FeedMessageRepository
+from .feed_message_classifier import classify_message
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_thread_mbox(subsystem: str, message_id_header: str) -> Optional[bytes]:
+    """Fetch the t.mbox.gz archive for a thread from lore.kernel.org.
+
+    Args:
+        subsystem: Subsystem name (e.g. "rust-for-linux")
+        message_id_header: Root message ID header
+
+    Returns:
+        Raw gzipped mbox bytes on success, None on error
+    """
+    url = f"https://lore.kernel.org/{subsystem}/{message_id_header}/t.mbox.gz"
+    try:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+            response = await client.get(url)
+            if response.status_code != 200:
+                logger.warning(
+                    "Failed to fetch thread mbox from %s (status %d)",
+                    url,
+                    response.status_code,
+                )
+                return None
+            return response.content
+    except httpx.HTTPError as e:
+        logger.warning("HTTP error fetching thread mbox from %s: %s", url, e)
+        return None
+
+
+def _decode_header(value: Optional[str]) -> str:
+    """Decode an RFC 2047 encoded email header."""
+    if not value:
+        return ""
+    parts = email.header.decode_header(value)
+    decoded = []
+    for data, charset in parts:
+        if isinstance(data, bytes):
+            decoded.append(data.decode(charset or "utf-8", errors="replace"))
+        else:
+            decoded.append(data)
+    return "".join(decoded)
+
+
+def _strip_angle_brackets(value: Optional[str]) -> Optional[str]:
+    """Strip angle brackets from a Message-ID string."""
+    if not value:
+        return None
+    value = value.strip()
+    if value.startswith("<") and value.endswith(">"):
+        return value[1:-1]
+    return value
+
+
+def _get_text_payload(msg: mailbox.mboxMessage) -> str:
+    """Extract text/plain content from an email message."""
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    return payload.decode(charset, errors="replace")
+        return ""
+    payload = msg.get_payload(decode=True)
+    if payload:
+        charset = msg.get_content_charset() or "utf-8"
+        return payload.decode(charset, errors="replace")
+    return ""
+
+
+def _parse_single_mbox_message(msg, subsystem_name: str) -> Optional[FeedMessageData]:
+    """Parse a single mbox message into FeedMessageData.
+
+    Returns:
+        FeedMessageData or None if parsing fails
+    """
+    mid = _strip_angle_brackets(msg.get("Message-ID"))
+    if not mid:
+        return None
+
+    in_reply_to = _strip_angle_brackets(msg.get("In-Reply-To"))
+    subject = _decode_header(msg.get("Subject", ""))
+    author_name, author_email = email.utils.parseaddr(
+        _decode_header(msg.get("From", ""))
+    )
+
+    received_at: Optional[datetime] = None
+    date_str = msg.get("Date")
+    if date_str:
+        try:
+            received_at = email.utils.parsedate_to_datetime(date_str)
+            if received_at.tzinfo is None:
+                received_at = received_at.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            received_at = None
+
+    classification = classify_message(
+        subject=subject,
+        in_reply_to_header=in_reply_to,
+        message_id_header=mid,
+    )
+    patch_info = classification.patch_info
+
+    return FeedMessageData(
+        subsystem_name=subsystem_name,
+        message_id_header=mid,
+        message_id=mid,
+        in_reply_to_header=in_reply_to,
+        subject=subject,
+        author=author_name or author_email or "unknown",
+        author_email=author_email or "unknown@example.com",
+        content=_get_text_payload(msg),
+        url=f"https://lore.kernel.org/{subsystem_name}/{mid}/",
+        received_at=received_at,
+        is_patch=classification.is_patch,
+        is_reply=classification.is_reply,
+        is_series_patch=classification.is_series_patch,
+        patch_version=patch_info.version if patch_info else None,
+        patch_index=patch_info.index if patch_info else None,
+        patch_total=patch_info.total if patch_info else None,
+        is_cover_letter=patch_info.is_cover_letter if patch_info else False,
+        series_message_id=classification.series_message_id,
+    )
+
+
+def parse_mbox_messages(mbox_data: bytes, subsystem_name: str) -> list[FeedMessageData]:
+    """Parse a gzipped mbox archive into FeedMessageData objects.
+
+    Args:
+        mbox_data: Raw gzipped mbox bytes
+        subsystem_name: Subsystem name for URL construction
+
+    Returns:
+        List of FeedMessageData parsed from the mbox
+    """
+    try:
+        raw = gzip.decompress(mbox_data)
+    except (gzip.BadGzipFile, OSError) as e:
+        logger.warning("Failed to decompress mbox data: %s", e)
+        return []
+
+    results: list[FeedMessageData] = []
+
+    with tempfile.NamedTemporaryFile(suffix=".mbox") as tmp:
+        tmp.write(raw)
+        tmp.flush()
+        mbox = mailbox.mbox(tmp.name)
+
+        for msg in mbox:
+            try:
+                parsed = _parse_single_mbox_message(msg, subsystem_name)
+                if parsed:
+                    results.append(parsed)
+            except (
+                ValueError,
+                TypeError,
+                KeyError,
+                UnicodeDecodeError,
+                AttributeError,
+                LookupError,
+            ):
+                logger.debug("Failed to parse mbox message", exc_info=True)
+                continue
+
+    logger.info("Parsed %d messages from mbox for %s", len(results), subsystem_name)
+    return results
+
+
+def find_root_patch_in_messages(
+    messages: list[FeedMessageData],
+) -> Optional[FeedMessageData]:
+    """Find the root patch (Cover Letter or single patch) in parsed mbox messages.
+
+    Looks for the primary patch message that should be used to create a PatchCard.
+
+    Args:
+        messages: List of FeedMessageData parsed from mbox
+
+    Returns:
+        The root patch FeedMessageData, or None if not found
+    """
+    # First: patch without in_reply_to (Cover Letter or standalone)
+    for msg in messages:
+        if msg.is_patch and not msg.is_reply and not msg.in_reply_to_header:
+            return msg
+    # Fallback: any non-reply patch message
+    for msg in messages:
+        if msg.is_patch and not msg.is_reply:
+            return msg
+    return None
+
+
+async def backfill_thread_replies(
+    session: AsyncSession, subsystem: str, message_id_header: str
+) -> int:
+    """Backfill existing thread replies from lore.kernel.org into the DB.
+
+    Args:
+        session: Database session
+        subsystem: Subsystem name
+        message_id_header: Root message ID header of the thread
+
+    Returns:
+        Number of newly saved messages
+    """
+    mbox_data = await fetch_thread_mbox(subsystem, message_id_header)
+    if not mbox_data:
+        return 0
+
+    messages = parse_mbox_messages(mbox_data, subsystem)
+    if not messages:
+        return 0
+
+    repo = FeedMessageRepository(session)
+    new_count = 0
+
+    for msg in messages:
+        existing = await repo.find_by_message_id_header(msg.message_id_header)
+        if existing:
+            continue
+        await repo.create_or_update(data=msg)
+        new_count += 1
+
+    if new_count > 0:
+        logger.info(
+            "Backfilled %d new messages (of %d total) for thread %s",
+            new_count,
+            len(messages),
+            message_id_header,
+        )
+
+    return new_count

--- a/src/lkml/service/__init__.py
+++ b/src/lkml/service/__init__.py
@@ -18,16 +18,14 @@ from .types import (
     PatchCard,
     FeedMessage,
     PatchThread,
+    ThreadNode,
     ThreadOverviewData,
 )
 from .query_service import QueryService, query_service
 from .service import LKMLService, lkml_service
 from .subsystem_service import SubsystemService, subsystem_service
 
-from .thread_service import (
-    ThreadService,
-    parse_reply_time,
-)
+from .thread_service import ThreadService
 from .feed_message_service import FeedMessageService
 
 
@@ -67,7 +65,6 @@ __all__ = [
     "PatchCard",
     "FeedMessage",
     "PatchThread",
+    "ThreadNode",
     "ThreadOverviewData",
-    # 回复处理辅助函数
-    "parse_reply_time",
 ]

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -476,24 +476,51 @@ class FeedMessageService:
             feed_message.in_reply_to_header
         )
 
-        # 2. 如果没找到，可能是回复子 PATCH 的情况
+        # 2. 如果没找到，可能是回复子 PATCH 或 reply-to-reply 的情况
+        #    沿 in_reply_to 链向上回溯，直到找到 patch_card 或有 series_message_id 的消息
         if not patch_card:
             feed_message_repo = FeedMessageRepository(session)
-            sub_patch_feed_message = await feed_message_repo.find_by_message_id_header(
+            current_msg = await feed_message_repo.find_by_message_id_header(
                 feed_message.in_reply_to_header
             )
 
-            # 如果找到了子 PATCH 的 feed_message，通过它的 series_message_id 查找 Cover Letter
-            if sub_patch_feed_message and sub_patch_feed_message.series_message_id:
-                patch_card = await patch_card_service.find_series_patch_card(
-                    sub_patch_feed_message.series_message_id
+            for _ in range(10):  # 最大回溯深度
+                if not current_msg:
+                    break
+
+                # 找到有 series_message_id 的消息 → 通过它查找 Cover Letter
+                if current_msg.series_message_id:
+                    patch_card = await patch_card_service.find_series_patch_card(
+                        current_msg.series_message_id
+                    )
+                    if patch_card:
+                        logger.debug(
+                            f"Found Cover Letter via reply chain series_message_id: "
+                            f"in_reply_to={feed_message.in_reply_to_header}, "
+                            f"series_message_id={current_msg.series_message_id}"
+                        )
+                    break
+
+                # 没有 series_message_id，尝试沿 in_reply_to 继续向上
+                if not current_msg.in_reply_to_header:
+                    break
+
+                # 尝试直接匹配 patch_card
+                patch_card = await patch_card_service.find_by_message_id_header(
+                    current_msg.in_reply_to_header
                 )
                 if patch_card:
                     logger.debug(
-                        f"Found Cover Letter via sub-patch series_message_id: "
+                        f"Found patch card via reply chain traversal: "
                         f"in_reply_to={feed_message.in_reply_to_header}, "
-                        f"series_message_id={sub_patch_feed_message.series_message_id}"
+                        f"patch_card={patch_card.message_id_header}"
                     )
+                    break
+
+                # 继续向上追溯
+                current_msg = await feed_message_repo.find_by_message_id_header(
+                    current_msg.in_reply_to_header
+                )
 
         if not patch_card:
             logger.debug(
@@ -986,10 +1013,10 @@ class FeedMessageService:
             )
             if not target_patch or target_patch_index is None:
                 logger.debug(
-                    "Could not find target patch for reply: %s",
+                    "Could not find target patch for reply (reply-to-reply): %s, "
+                    "will still update overview",
                     in_reply_to_header,
                 )
-                return
 
             message_id = self._get_thread_overview_message_id(thread)
             if not message_id:

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -331,6 +331,10 @@ class FeedMessageService:
             is_cover_letter=service_feed_message.is_cover_letter,
             series_patches=series_patches,
             matched_filters=service_feed_message.matched_filters,
+            content=feed_message.content,
+            received_at=feed_message.received_at,
+            author_email=feed_message.author_email,
+            to_cc_list=getattr(feed_message, "to_cc_list", None),
         )
 
     async def _save_patch_card_to_database(
@@ -615,6 +619,7 @@ class FeedMessageService:
 
         payload = {
             "reply_author": reply_message.author_email or reply_message.author,
+            "reply_author_name": reply_message.author or "",
             "reply_subject": reply_message.subject or "",
             "reply_url": reply_message.url,
             "reply_subsystem": reply_message.subsystem_name or "",
@@ -623,6 +628,7 @@ class FeedMessageService:
                 if reply_message.received_at
                 else ""
             ),
+            "reply_content": reply_message.content or "",
             "root_subject": root_patch.subject or "",
             "root_url": root_patch.url,
         }
@@ -796,13 +802,19 @@ class FeedMessageService:
         await patch_card_service.mark_as_has_thread(patch_card.message_id_header)
 
     async def _send_thread_update_notification(
-        self, thread: PatchThread, patch_card: PatchCard
+        self,
+        thread: PatchThread,
+        patch_card: PatchCard,
+        reply_author: str = "",
+        reply_summary: str = "",
     ):
         """发送 Thread 更新通知到频道
 
         Args:
             thread: Thread 对象
             patch_card: PATCH 卡片对象
+            reply_author: 回复者名称
+            reply_summary: 回复的 AI 摘要
         """
         try:
             # 使用新的 thread_sender（如果可用）
@@ -819,6 +831,8 @@ class FeedMessageService:
                     channel_id,
                     thread.thread_id,
                     patch_card.platform_message_id,
+                    reply_author=reply_author,
+                    reply_summary=reply_summary,
                 )
 
                 if success:
@@ -843,50 +857,24 @@ class FeedMessageService:
         thread: PatchThread,
         patch_card: PatchCard,
         reply_feed_message: FeedMessageData,
-    ):
-        """当 Reply 到达时，更新 Thread
-
-        根据是否配置了 ``thread_sender``，选择对应的更新实现。
-
-        Args:
-            session: 数据库会话（用于查询，确保能查询到新保存的 REPLY）
-            thread: Thread 对象
-            patch_card: PATCH 卡片对象
-            reply_feed_message: Reply 消息对象
-        """
-        if self.thread_sender:
-            await self._update_thread_with_reply_via_thread_sender(
-                session, thread, patch_card, reply_feed_message
-            )
+    ) -> None:
+        """当 Reply 到达时，更新 Thread Overview"""
+        if not self.thread_sender:
             return
 
-        in_reply_to_header = reply_feed_message.in_reply_to_header or ""
-        await self._update_thread_with_reply_via_renderers(
-            session, thread, patch_card, in_reply_to_header
-        )
-
-    async def _update_thread_with_reply_via_thread_sender(
-        self,
-        session: AsyncSession,
-        thread: PatchThread,
-        patch_card: PatchCard,
-        reply_feed_message: FeedMessageData,
-    ) -> None:
-        """当 Reply 到达时，使用 ``thread_sender`` 更新 Thread。"""
         try:
             in_reply_to_header = reply_feed_message.in_reply_to_header or ""
             target_patch, target_patch_index = await self._find_target_patch_for_reply(
                 patch_card, in_reply_to_header
             )
-
             if not target_patch or target_patch_index is None:
                 logger.debug(
-                    "Could not find target patch for reply: %s", in_reply_to_header
+                    "Could not find target patch for reply: %s",
+                    in_reply_to_header,
                 )
                 return
 
             message_id = self._get_thread_overview_message_id(thread)
-
             if not message_id:
                 logger.warning(
                     "No overview message_id found for thread %s",
@@ -897,7 +885,6 @@ class FeedMessageService:
             overview_data = await self._prepare_thread_overview_data(
                 session, patch_card.message_id_header
             )
-
             if not overview_data:
                 return
 
@@ -912,13 +899,17 @@ class FeedMessageService:
                 overview_data,
                 reply_summary=reply_summary,
             )
-
             if success:
                 logger.info(
                     "Updated thread overview message in thread %s",
                     thread.thread_id,
                 )
-                await self._send_thread_update_notification(thread, patch_card)
+                await self._send_thread_update_notification(
+                    thread,
+                    patch_card,
+                    reply_author=reply_feed_message.author or "",
+                    reply_summary=reply_summary,
+                )
             else:
                 logger.warning(
                     "Failed to update thread overview message in thread %s",
@@ -956,78 +947,6 @@ class FeedMessageService:
             )
 
         return summary
-
-    async def _update_thread_with_reply_via_renderers(
-        self,
-        session: AsyncSession,
-        thread: PatchThread,
-        patch_card: PatchCard,
-        in_reply_to_header: str,
-    ) -> None:
-        """当 Reply 到达时，通过渲染器列表更新 Thread。"""
-        try:
-            target_patch, target_patch_index = await self._find_target_patch_for_reply(
-                patch_card, in_reply_to_header
-            )
-
-            if not target_patch or target_patch_index is None:
-                logger.debug(
-                    "Could not find target patch for reply: %s", in_reply_to_header
-                )
-                return
-
-            message_id = self._get_thread_overview_message_id(thread)
-
-            if not message_id:
-                logger.warning(
-                    "No overview message_id found for thread %s",
-                    thread.thread_id,
-                )
-                return
-
-            overview_data = await self._prepare_thread_overview_data(
-                session, patch_card.message_id_header
-            )
-
-            if not overview_data:
-                return
-
-            successes: list[bool] = []
-            for renderer in self.thread_overview_renderers:
-                try:
-                    result = await renderer.update_sub_patch_message(
-                        thread.thread_id,
-                        message_id,
-                        overview_data,
-                    )
-                    successes.append(bool(result))
-                except (RuntimeError, ValueError, AttributeError) as e:
-                    successes.append(False)
-                    logger.error(
-                        "Failed to update patch [%s] message in thread %s: %s",
-                        target_patch_index,
-                        thread.thread_id,
-                        e,
-                        exc_info=True,
-                    )
-
-            if any(successes):
-                logger.info(
-                    "Updated thread overview message in thread %s",
-                    thread.thread_id,
-                )
-                await self._send_thread_update_notification(thread, patch_card)
-            else:
-                logger.warning(
-                    "Failed to update thread overview message in thread %s",
-                    thread.thread_id,
-                )
-        except (RuntimeError, ValueError, AttributeError) as e:
-            logger.error(
-                "Failed to update thread with reply: %s",
-                e,
-                exc_info=True,
-            )
 
     async def _find_target_patch_for_reply(
         self, patch_card: PatchCard, in_reply_to_header: str

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -806,7 +806,11 @@ class FeedMessageService:
         thread: PatchThread,
         patch_card: PatchCard,
         reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
         reply_summary: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ):
         """发送 Thread 更新通知到频道
 
@@ -814,7 +818,11 @@ class FeedMessageService:
             thread: Thread 对象
             patch_card: PATCH 卡片对象
             reply_author: 回复者名称
+            reply_author_email: 回复者邮箱
+            reply_date: 回复日期字符串
             reply_summary: 回复的 AI 摘要
+            reply_url: 回复在 lore.kernel.org 上的链接
+            reply_content: 回复的原始内容（用于 fallback 摘要）
         """
         try:
             # 使用新的 thread_sender（如果可用）
@@ -832,7 +840,11 @@ class FeedMessageService:
                     thread.thread_id,
                     patch_card.platform_message_id,
                     reply_author=reply_author,
+                    reply_author_email=reply_author_email,
+                    reply_date=reply_date,
                     reply_summary=reply_summary,
+                    reply_url=reply_url,
+                    reply_content=reply_content,
                 )
 
                 if success:
@@ -893,11 +905,22 @@ class FeedMessageService:
                 session, reply_feed_message
             )
 
+            reply_date_str = ""
+            if reply_feed_message.received_at:
+                reply_date_str = reply_feed_message.received_at.strftime(
+                    "%Y-%m-%d %H:%M UTC"
+                )
+
             success = await self.thread_sender.update_thread_overview(
                 thread.thread_id,
                 message_id,
                 overview_data,
                 reply_summary=reply_summary,
+                reply_author=reply_feed_message.author or "",
+                reply_author_email=reply_feed_message.author_email or "",
+                reply_date=reply_date_str,
+                reply_url=reply_feed_message.url or "",
+                reply_content=reply_feed_message.content or "",
             )
             if success:
                 logger.info(
@@ -908,7 +931,11 @@ class FeedMessageService:
                     thread,
                     patch_card,
                     reply_author=reply_feed_message.author or "",
+                    reply_author_email=reply_feed_message.author_email or "",
+                    reply_date=reply_date_str,
                     reply_summary=reply_summary,
+                    reply_url=reply_feed_message.url or "",
+                    reply_content=reply_feed_message.content or "",
                 )
             else:
                 logger.warning(

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -51,16 +51,19 @@ class FeedMessageService:
         self,
         patch_card_sender=None,
         thread_sender=None,
+        summarizer=None,
     ):
         """初始化处理器
 
         Args:
             patch_card_sender: PatchCard 多平台发送服务
             thread_sender: Thread 多平台发送服务
+            summarizer: 可选的 AI 内容摘要服务
         """
         # 通过统一的多平台发送服务发送（由 Plugins 层注入）
         self.patch_card_sender = patch_card_sender
         self.thread_sender = thread_sender
+        self.summarizer = summarizer
 
     # ========== 公共方法 ==========
 
@@ -235,6 +238,14 @@ class FeedMessageService:
             )
         )
 
+        # AI 摘要（可选，失败时静默 fallback）
+        if self.summarizer and temp_patch_card.content:
+            summary = await self.summarizer.summarize(
+                temp_patch_card.content, temp_patch_card.subject
+            )
+            if summary:
+                temp_patch_card.summary = summary
+
         # 使用 PatchCard 发送服务（如果已注入）
         platform_message_id = None
         platform_channel_id = ""
@@ -262,7 +273,8 @@ class FeedMessageService:
 
         # 保存到数据库
         return await self._save_patch_card_to_database(
-            session, service_feed_message, platform_message_id, platform_channel_id
+            session, service_feed_message, platform_message_id, platform_channel_id,
+            summary=temp_patch_card.summary,
         )
 
     async def _get_series_patches_for_cover_letter(  # pylint: disable=too-many-arguments
@@ -322,7 +334,8 @@ class FeedMessageService:
         )
 
     async def _save_patch_card_to_database(
-        self, session, service_feed_message, platform_message_id, platform_channel_id
+        self, session, service_feed_message, platform_message_id, platform_channel_id,
+        summary=None,
     ):
         """保存 PATCH 卡片到数据库"""
         patch_card_repo = PatchCardRepository(session)
@@ -334,6 +347,7 @@ class FeedMessageService:
             platform_message_id=platform_message_id,
             platform_channel_id=platform_channel_id,
             timeout_hours=24,
+            summary=summary,
         )
 
     async def _process_reply_message(
@@ -363,7 +377,7 @@ class FeedMessageService:
             # 更新 Thread：如果是多消息模式，只更新对应的子 PATCH 消息
             # 传入 session 以确保能查询到新保存的 REPLY（还在同一事务中）
             await self._update_thread_with_reply(
-                session, thread, patch_card, feed_message.in_reply_to_header
+                session, thread, patch_card, feed_message
             )
             return
 
@@ -513,7 +527,7 @@ class FeedMessageService:
             if not patch_card:
                 return
 
-            await self._send_reply_notice(reply_message, target_patch)
+            await self._send_reply_notice(session, reply_message, target_patch)
 
             if await self._is_auto_watch_enabled(session, matched_filters):
                 await self._auto_watch_patch_card(session, patch_card)
@@ -589,7 +603,8 @@ class FeedMessageService:
         return await config_repo.get_auto_watch_enabled()
 
     async def _send_reply_notice(
-        self, reply_message: FeedMessageData, root_patch: FeedMessageData
+        self, session: AsyncSession, reply_message: FeedMessageData,
+        root_patch: FeedMessageData,
     ) -> None:
         """发送 Reply 视角通知消息"""
         if not self.patch_card_sender:
@@ -611,6 +626,22 @@ class FeedMessageService:
             "root_subject": root_patch.subject or "",
             "root_url": root_patch.url,
         }
+
+        # AI 摘要（可选，失败时静默 fallback）
+        summary = None
+        if self.summarizer and reply_message.content:
+            summary = await self.summarizer.summarize(
+                reply_message.content, reply_message.subject or "", is_reply=True
+            )
+        payload["reply_summary"] = summary or ""
+
+        # 持久化摘要到数据库
+        if summary and reply_message.message_id_header:
+            feed_message_repo = FeedMessageRepository(session)
+            await feed_message_repo.update_summary(
+                reply_message.message_id_header, summary
+            )
+
         await self.patch_card_sender.send_reply_notification(payload)
 
     async def _resolve_patch_feed_message_for_reply(
@@ -811,7 +842,7 @@ class FeedMessageService:
         session: AsyncSession,
         thread: PatchThread,
         patch_card: PatchCard,
-        in_reply_to_header: str,
+        reply_feed_message: FeedMessageData,
     ):
         """当 Reply 到达时，更新 Thread
 
@@ -821,14 +852,15 @@ class FeedMessageService:
             session: 数据库会话（用于查询，确保能查询到新保存的 REPLY）
             thread: Thread 对象
             patch_card: PATCH 卡片对象
-            in_reply_to_header: Reply 的 in_reply_to 头部
+            reply_feed_message: Reply 消息对象
         """
         if self.thread_sender:
             await self._update_thread_with_reply_via_thread_sender(
-                session, thread, patch_card, in_reply_to_header
+                session, thread, patch_card, reply_feed_message
             )
             return
 
+        in_reply_to_header = reply_feed_message.in_reply_to_header or ""
         await self._update_thread_with_reply_via_renderers(
             session, thread, patch_card, in_reply_to_header
         )
@@ -838,10 +870,11 @@ class FeedMessageService:
         session: AsyncSession,
         thread: PatchThread,
         patch_card: PatchCard,
-        in_reply_to_header: str,
+        reply_feed_message: FeedMessageData,
     ) -> None:
         """当 Reply 到达时，使用 ``thread_sender`` 更新 Thread。"""
         try:
+            in_reply_to_header = reply_feed_message.in_reply_to_header or ""
             target_patch, target_patch_index = await self._find_target_patch_for_reply(
                 patch_card, in_reply_to_header
             )
@@ -868,10 +901,16 @@ class FeedMessageService:
             if not overview_data:
                 return
 
+            # AI 摘要（可选，失败时静默 fallback）
+            reply_summary = await self._generate_and_persist_reply_summary(
+                session, reply_feed_message
+            )
+
             success = await self.thread_sender.update_thread_overview(
                 thread.thread_id,
                 message_id,
                 overview_data,
+                reply_summary=reply_summary,
             )
 
             if success:
@@ -891,6 +930,32 @@ class FeedMessageService:
                 e,
                 exc_info=True,
             )
+
+    async def _generate_and_persist_reply_summary(
+        self, session: AsyncSession, reply_message: FeedMessageData
+    ) -> str:
+        """为 reply 生成 AI 摘要并持久化到数据库
+
+        Returns:
+            摘要文本，失败时返回空字符串
+        """
+        if not self.summarizer or not reply_message.content:
+            return ""
+
+        summary = await self.summarizer.summarize(
+            reply_message.content, reply_message.subject or "", is_reply=True
+        )
+        if not summary:
+            return ""
+
+        # 持久化到数据库
+        if reply_message.message_id_header:
+            feed_message_repo = FeedMessageRepository(session)
+            await feed_message_repo.update_summary(
+                reply_message.message_id_header, summary
+            )
+
+        return summary
 
     async def _update_thread_with_reply_via_renderers(
         self,

--- a/src/lkml/service/feed_message_service.py
+++ b/src/lkml/service/feed_message_service.py
@@ -89,6 +89,31 @@ class FeedMessageService:
 
     # ========== 私有方法 ==========
 
+    async def _save_series_sub_patch_if_tracked(
+        self,
+        session: AsyncSession,
+        feed_message: FeedMessageData,
+        series_message_id: str,
+    ) -> None:
+        """Save series sub-patch to DB if the series is already tracked."""
+        from ..db.database import get_patch_card_service
+
+        async with get_patch_card_service() as svc:
+            if await svc.find_series_patch_card(series_message_id):
+                repo = FeedMessageRepository(session)
+                await repo.create_or_update(data=feed_message)
+
+    def _is_series_sub_patch(self, feed_message, classification) -> bool:
+        """Check if this is a series sub-patch (not Cover Letter)."""
+        patch_info = classification.patch_info
+        if not (classification.series_message_id and patch_info):
+            return False
+        return not (
+            patch_info.is_cover_letter
+            or feed_message.is_cover_letter
+            or (patch_info.index is not None and patch_info.index == 0)
+        )
+
     async def _process_patch_message(
         self,
         session: AsyncSession,
@@ -125,7 +150,6 @@ class FeedMessageService:
 
         # 创建新的 PATCH 卡片并发送到 Discord
         try:
-            # 检查渲染器是否可用
             if not self.patch_card_sender:
                 logger.debug(
                     f"PatchCard renderer not configured, skipping PATCH card creation: "
@@ -133,46 +157,39 @@ class FeedMessageService:
                 )
                 return
 
-            # 从分类结果中获取 PATCH 信息
-            patch_info = classification.patch_info
-            # Series PATCH 处理：只发送 Cover Letter，子 PATCH 不单独创建卡片
-            if classification.series_message_id and patch_info:
-                if not (
-                    patch_info.is_cover_letter
-                    or feed_message.is_cover_letter
-                    or (patch_info.index is not None and patch_info.index == 0)
-                ):
-                    # 子 PATCH (1/n, 2/n, ...) 只保存在 feed_message 表中
-                    logger.debug(
-                        f"Skipping patch_card creation for series sub-PATCH: "
-                        f"{feed_message.message_id_header}, "
-                        f"subject: {feed_message.subject[:50]}, "
-                        f"patch_index: {patch_info.index}/{patch_info.total}. "
-                        f"Sub-patch is stored in feed_message table only."
-                    )
-                    return
-
-            # 准备 Service 层的 FeedMessage 对象
-            service_feed_message = self._convert_to_service_feed_message(
-                feed_message, patch_info, classification.series_message_id
-            )
-
-            # 应用过滤规则（在默认 filter 基础上）
-            should_create, matched_filters = await self._should_create_patch_card(
-                session, service_feed_message, patch_info
-            )
-            if not should_create:
+            # Series sub-patch: save to DB if tracked, but don't create card
+            if self._is_series_sub_patch(feed_message, classification):
+                await self._save_series_sub_patch_if_tracked(
+                    session,
+                    feed_message,
+                    classification.series_message_id,
+                )
                 logger.debug(
-                    f"Patch card creation filtered out by rules: {feed_message.message_id_header}, "
+                    f"Skipping patch_card creation for series sub-PATCH: "
+                    f"{feed_message.message_id_header}, "
                     f"subject: {feed_message.subject[:50]}"
                 )
                 return
 
-            # 将匹配的过滤规则名称传递给 service_feed_message（用于后续渲染）
+            patch_info = classification.patch_info
+            service_feed_message = self._convert_to_service_feed_message(
+                feed_message, patch_info, classification.series_message_id
+            )
+
+            # 应用过滤规则
+            should_create, matched_filters = await self._should_create_patch_card(
+                session, service_feed_message, patch_info
+            )
+            if not should_create:
+                return
+
+            # Filter passed → persist feed_message to DB
+            repo = FeedMessageRepository(session)
+            await repo.create_or_update(data=feed_message)
+
             if matched_filters:
                 service_feed_message.matched_filters = matched_filters
 
-            # 检查 PATCH 卡片是否已存在
             async with get_patch_card_service() as service:
                 patch_card = await service.get_patch_card_with_series_data(
                     feed_message.message_id_header
@@ -182,9 +199,8 @@ class FeedMessageService:
                 session, matched_filters
             )
 
-            # PATCH 卡片不存在，准备创建
             if not patch_card:
-                patch_card = await self._create_and_send_patch_card(  # pylint: disable=too-many-arguments
+                patch_card = await self._create_and_send_patch_card(
                     session,
                     feed_message,
                     service_feed_message,
@@ -273,7 +289,10 @@ class FeedMessageService:
 
         # 保存到数据库
         return await self._save_patch_card_to_database(
-            session, service_feed_message, platform_message_id, platform_channel_id,
+            session,
+            service_feed_message,
+            platform_message_id,
+            platform_channel_id,
             summary=temp_patch_card.summary,
         )
 
@@ -338,7 +357,11 @@ class FeedMessageService:
         )
 
     async def _save_patch_card_to_database(
-        self, session, service_feed_message, platform_message_id, platform_channel_id,
+        self,
+        session,
+        service_feed_message,
+        platform_message_id,
+        platform_channel_id,
         summary=None,
     ):
         """保存 PATCH 卡片到数据库"""
@@ -378,8 +401,10 @@ class FeedMessageService:
 
         # 已建立并激活 Thread：保持现状，仅更新 Thread
         if patch_card and thread and thread.is_active:
-            # 更新 Thread：如果是多消息模式，只更新对应的子 PATCH 消息
-            # 传入 session 以确保能查询到新保存的 REPLY（还在同一事务中）
+            # Parent tracked → persist reply to DB
+            repo = FeedMessageRepository(session)
+            await repo.create_or_update(data=feed_message)
+
             await self._update_thread_with_reply(
                 session, thread, patch_card, feed_message
             )
@@ -502,6 +527,10 @@ class FeedMessageService:
                 patch_context
             )
 
+            # Reply perspective matched → persist the reply itself
+            repo = FeedMessageRepository(session)
+            await repo.create_or_update(data=reply_message)
+
             if matched_filters:
                 service_feed_message.matched_filters = matched_filters
 
@@ -542,6 +571,31 @@ class FeedMessageService:
                 exc_info=True,
             )
 
+    async def _mbox_fallback_resolve(
+        self,
+        reply_message: FeedMessageData,
+    ) -> tuple[Optional[FeedMessageData], Optional[list[FeedMessageData]]]:
+        """Try to resolve target patch via mbox when parent is not in DB.
+
+        Returns:
+            (target_patch, mbox_messages) tuple
+        """
+        from ..feed.thread_backfill import (
+            fetch_thread_mbox,
+            find_root_patch_in_messages,
+            parse_mbox_messages,
+        )
+
+        mbox_data = await fetch_thread_mbox(
+            reply_message.subsystem_name,
+            reply_message.in_reply_to_header,
+        )
+        if not mbox_data:
+            return None, None
+
+        mbox_messages = parse_mbox_messages(mbox_data, reply_message.subsystem_name)
+        return find_root_patch_in_messages(mbox_messages), mbox_messages
+
     async def _build_reply_patch_context(
         self, session: AsyncSession, reply_message: FeedMessageData
     ) -> Optional[tuple[FeedMessageData, object, ServiceFeedMessage, list[str]]]:
@@ -549,6 +603,14 @@ class FeedMessageService:
         target_patch = await self._resolve_patch_feed_message_for_reply(
             session, reply_message
         )
+
+        # mbox fallback: when parent not in DB, fetch from lore
+        mbox_messages: Optional[list[FeedMessageData]] = None
+        if not target_patch:
+            target_patch, mbox_messages = await self._mbox_fallback_resolve(
+                reply_message,
+            )
+
         if not target_patch or not target_patch.subject:
             return None
 
@@ -565,11 +627,14 @@ class FeedMessageService:
         should_create, matched_filters = await self._should_create_patch_card(
             session, filter_message, patch_info
         )
-        if not should_create:
+        if not should_create or not matched_filters:
             return None
-        if not matched_filters:
-            # Reply 视角必须命中过滤规则才触发后续处理
-            return None
+
+        # Filter passed → persist mbox messages to DB
+        if mbox_messages:
+            repo = FeedMessageRepository(session)
+            for msg in mbox_messages:
+                await repo.create_or_update(data=msg)
 
         # Patch Card 创建数据仍使用 Patch 本身
         service_feed_message = self._convert_to_service_feed_message(
@@ -607,7 +672,9 @@ class FeedMessageService:
         return await config_repo.get_auto_watch_enabled()
 
     async def _send_reply_notice(
-        self, session: AsyncSession, reply_message: FeedMessageData,
+        self,
+        session: AsyncSession,
+        reply_message: FeedMessageData,
         root_patch: FeedMessageData,
     ) -> None:
         """发送 Reply 视角通知消息"""
@@ -778,7 +845,10 @@ class FeedMessageService:
         thread_name = patch_card.subject[:100]
         thread_id, sub_patch_messages = (
             await self.thread_sender.create_thread_and_send_overview(
-                thread_name, patch_card.platform_message_id, overview_data
+                thread_name,
+                patch_card.platform_message_id,
+                overview_data,
+                skip_feishu_create=True,
             )
         )
 
@@ -800,6 +870,41 @@ class FeedMessageService:
             )
 
         await patch_card_service.mark_as_has_thread(patch_card.message_id_header)
+
+        # Backfill existing replies from lore
+        try:
+            from lkml.feed.thread_backfill import backfill_thread_replies
+
+            new_count = await backfill_thread_replies(
+                session,
+                patch_card.subsystem_name,
+                patch_card.message_id_header,
+            )
+            if new_count > 0 and sub_patch_messages:
+                logger.info(
+                    "Backfilled %d messages for %s",
+                    new_count,
+                    patch_card.message_id_header,
+                )
+                # Re-prepare and update overview
+                updated_overview = await thread_service.prepare_thread_overview_data(
+                    patch_card.message_id_header,
+                    patch_card_service=patch_card_service,
+                )
+                if updated_overview:
+                    overview_msg_id = next(iter(sub_patch_messages.values()), None)
+                    if overview_msg_id:
+                        await self.thread_sender.update_thread_overview(
+                            thread_id,
+                            overview_msg_id,
+                            updated_overview,
+                        )
+        except (RuntimeError, ValueError, AttributeError, OSError, KeyError):
+            logger.warning(
+                "Thread backfill failed for %s",
+                patch_card.message_id_header,
+                exc_info=True,
+            )
 
     async def _send_thread_update_notification(
         self,

--- a/src/lkml/service/helpers.py
+++ b/src/lkml/service/helpers.py
@@ -41,6 +41,7 @@ def extract_common_patch_card_fields(data: Any) -> Dict[str, Any]:
         "patch_total": data.patch_total,
         "has_thread": getattr(data, "has_thread", False),
         "to_cc_list": getattr(data, "to_cc_list", None),
+        "summary": getattr(data, "summary", None),
         # 注意：is_cover_letter 不在数据库中存储，只在 Service 层使用
     }
 

--- a/src/lkml/service/patch_card_service.py
+++ b/src/lkml/service/patch_card_service.py
@@ -5,6 +5,7 @@ Service 层通过依赖注入接受 Repository 实例。
 """
 
 import logging
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, List
 
 from .types import PatchCard, SeriesPatchInfo
@@ -259,6 +260,7 @@ class PatchCardService:
         platform_message_id: str,
         platform_channel_id: str,
         timeout_hours: int = 24,
+        summary: Optional[str] = None,
     ) -> Optional[PatchCard]:
         """创建 PatchCard（供 Plugins 层使用，包含所有业务逻辑）
 
@@ -279,11 +281,8 @@ class PatchCardService:
             创建的 PatchCard（包含 series_patches），失败返回 None
         """
         try:
-            from datetime import timedelta
-            from datetime import datetime as dt
-
             # 计算过期时间（业务逻辑）
-            expires_at = dt.utcnow() + timedelta(hours=timeout_hours)
+            expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
 
             # 判断是否是系列 PATCH（业务逻辑）
             is_series = feed_message.is_series_patch or (
@@ -316,6 +315,7 @@ class PatchCardService:
                 has_thread=False,
                 is_cover_letter=feed_message.is_cover_letter,
                 to_cc_list=to_cc_list,
+                summary=summary,
             )
 
             # 保存到数据库

--- a/src/lkml/service/summarizer.py
+++ b/src/lkml/service/summarizer.py
@@ -1,0 +1,74 @@
+"""AI 内容摘要服务（Gemini Flash-Lite）
+
+可选服务：当配置了 Gemini API Key 时，为 PATCH 内容生成一句话摘要。
+失败/超时时静默 fallback，不影响主流程。
+"""
+
+import logging
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class ContentSummarizer:
+    """可选的 AI 内容摘要服务（Gemini Flash-Lite）"""
+
+    ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+    DEFAULT_MODEL = "gemini-2.5-flash-lite"
+    TIMEOUT = 15.0
+    MAX_CONTENT_CHARS = 1000
+
+    def __init__(self, api_key: str, model: str = DEFAULT_MODEL):
+        self.api_key = api_key
+        self.model = model
+
+    async def summarize(
+        self, content: str, subject: str, is_reply: bool = False
+    ) -> Optional[str]:
+        """生成一句话摘要。失败/超时返回 None，不影响主流程。"""
+        if not self.api_key or not content:
+            return None
+
+        truncated = content[: self.MAX_CONTENT_CHARS]
+        if is_reply:
+            prompt = (
+                "Summarize this Linux kernel mailing list reply in one concise "
+                "sentence (in Chinese). Focus on the reviewer's opinion or feedback. "
+                f"Title: {subject}\nContent:\n{truncated}"
+            )
+        else:
+            prompt = (
+                "Summarize this Linux kernel patch in one concise sentence "
+                f"(in Chinese). Title: {subject}\nContent:\n{truncated}"
+            )
+
+        url = self.ENDPOINT.format(model=self.model)
+        body = {"contents": [{"parts": [{"text": prompt}]}]}
+
+        try:
+            async with httpx.AsyncClient(timeout=self.TIMEOUT) as client:
+                resp = await client.post(url, json=body, params={"key": self.api_key})
+                resp.raise_for_status()
+                data = resp.json()
+                text = (
+                    data.get("candidates", [{}])[0]
+                    .get("content", {})
+                    .get("parts", [{}])[0]
+                    .get("text", "")
+                )
+                return text.strip() if text.strip() else None
+        except httpx.TimeoutException:
+            logger.warning("Gemini summarize timeout for: %s", subject[:80])
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                "Gemini summarize HTTP %s for: %s", e.response.status_code, subject[:80]
+            )
+            return None
+        except (ValueError, KeyError, TypeError, httpx.RequestError):
+            logger.warning(
+                "Gemini summarize failed for: %s", subject[:80], exc_info=True
+            )
+            return None

--- a/src/lkml/service/thread_service.py
+++ b/src/lkml/service/thread_service.py
@@ -1,7 +1,7 @@
 """Thread 服务
 
 封装 Thread 相关的数据库操作和内容处理，提供业务逻辑层接口。
-包括 Thread 的 CRUD 操作、回复处理、回复层级构建、PATCH 查找等功能。
+包括 Thread 的 CRUD 操作、回复处理、层级树构建等功能。
 Service 层通过依赖注入接受 Repository 实例。
 """
 
@@ -17,40 +17,13 @@ from ..db.repo import (
 )
 from .types import (
     PatchThread,
+    PatchCard,
     ThreadOverviewData,
-    ReplyHierarchy,
-    ReplyMapEntry,
+    ThreadNode,
     FeedMessage,
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ========== 回复处理辅助函数 ==========
-
-
-def parse_reply_time(reply) -> Optional[datetime]:
-    """解析回复时间
-
-    Args:
-        reply: FeedMessage 对象
-
-    Returns:
-        datetime 对象，如果解析失败则返回 None
-    """
-    if not reply.received_at:
-        return None
-
-    try:
-        # FeedMessage.received_at 是 datetime 对象，直接返回
-        reply_time = reply.received_at
-        if reply_time.tzinfo:
-            reply_time = reply_time.astimezone(datetime.now().astimezone().tzinfo)
-        else:
-            reply_time = reply_time.replace(tzinfo=datetime.now().astimezone().tzinfo)
-        return reply_time
-    except (ValueError, TypeError):
-        return None
 
 
 def _extract_message_id_from_header(in_reply_to_header: Optional[str]) -> Optional[str]:
@@ -79,132 +52,6 @@ def _extract_message_id_from_header(in_reply_to_header: Optional[str]) -> Option
         return parts[0].strip()
 
     return cleaned if cleaned else None
-
-
-async def _find_parent_reply_in_list(  # pylint: disable=too-many-return-statements
-    session,
-    in_reply_to: str,
-    reply_map: Dict[str, ReplyMapEntry],
-    patch_message_id: str,
-    max_depth: int = 5,
-) -> Optional[str]:
-    """在回复列表中查找父回复
-
-    递归查找 in_reply_to 链，直到找到在回复列表中的父回复
-
-    Args:
-        session: 数据库会话
-        in_reply_to: 回复的 in_reply_to_header
-        reply_map: 回复映射字典
-        patch_message_id: PATCH 的 message_id
-        max_depth: 最大递归深度
-
-    Returns:
-        父回复的 message_id_header，如果找不到则返回 None
-    """
-    if max_depth <= 0 or not in_reply_to:
-        return None
-
-    # 提取 message_id（处理尖括号、多个 message_id 等情况）
-    extracted_id = _extract_message_id_from_header(in_reply_to)
-    if not extracted_id:
-        return None
-
-    # 检查是否是直接回复 PATCH
-    if extracted_id == patch_message_id or patch_message_id in extracted_id:
-        return None  # 对 PATCH 的直接回复，没有父回复
-
-    # 在回复列表中查找
-    if extracted_id in reply_map:
-        return extracted_id
-
-    # 尝试模糊匹配（处理带尖括号等情况）
-    for reply_id in reply_map:
-        if extracted_id in reply_id or reply_id in extracted_id:
-            return reply_id
-
-    # 如果找不到，递归查找 in_reply_to 链
-    feed_message_repo = FeedMessageRepository(session)
-    feed_msg = await feed_message_repo.find_by_message_id_header(extracted_id)
-    if feed_msg and feed_msg.in_reply_to_header:
-        return await _find_parent_reply_in_list(
-            session,
-            feed_msg.in_reply_to_header,
-            reply_map,
-            patch_message_id,
-            max_depth - 1,
-        )
-
-    return None
-
-
-async def build_reply_hierarchy_internal(
-    session, patch_replies: list, patch_message_id: str
-) -> ReplyHierarchy:
-    """构建回复层级关系
-
-    通过递归查找 in_reply_to 链来确定真正的父回复
-
-    Args:
-        session: 数据库会话
-        patch_replies: 回复列表（应该已经按时间正序排序）
-        patch_message_id: PATCH 的 message_id
-
-    Returns:
-        回复层级结构
-    """
-    # 构建回复映射
-    reply_map: Dict[str, ReplyMapEntry] = {}
-    root_replies: List[str] = []
-
-    for reply in patch_replies:
-        reply_map[reply.message_id_header] = ReplyMapEntry(reply=reply, children=[])
-
-    # 构建层级关系
-    for reply in patch_replies:
-        in_reply_to_raw = reply.in_reply_to_header
-        if not in_reply_to_raw:
-            # 没有 in_reply_to，作为根回复
-            root_replies.append(reply.message_id_header)
-            continue
-
-        # 提取 message_id（处理尖括号、多个 message_id 等情况）
-        in_reply_to = _extract_message_id_from_header(in_reply_to_raw)
-
-        if not in_reply_to:
-            # 无法提取 message_id，作为根回复
-            root_replies.append(reply.message_id_header)
-            continue
-
-        # 检查是否是直接回复 PATCH
-        if in_reply_to == patch_message_id or patch_message_id in in_reply_to:
-            root_replies.append(reply.message_id_header)
-            continue
-
-        # 查找父回复（递归查找 in_reply_to 链）
-        parent_id = await _find_parent_reply_in_list(
-            session, in_reply_to_raw, reply_map, patch_message_id
-        )
-
-        if parent_id:
-            # 找到父回复，作为子回复
-            reply_map[parent_id].children.append(reply.message_id_header)
-        else:
-            # 找不到父回复，作为根回复处理
-            root_replies.append(reply.message_id_header)
-
-    # 对根回复按时间正序排序
-    root_replies.sort(
-        key=lambda rid: parse_reply_time(reply_map[rid].reply) or datetime.min
-    )
-
-    # 对每个回复的子回复也按时间正序排序
-    for reply_entry in reply_map.values():
-        reply_entry.children.sort(
-            key=lambda cid: parse_reply_time(reply_map[cid].reply) or datetime.min
-        )
-
-    return ReplyHierarchy(reply_map=reply_map, root_replies=root_replies)
 
 
 # ========== ThreadService 类 ==========
@@ -417,26 +264,6 @@ class ThreadService:
             )
             return False
 
-    # ========== 回复处理相关 ==========
-
-    async def build_reply_hierarchy(
-        self, patch_replies: list, patch_message_id: str
-    ) -> ReplyHierarchy:
-        """构建回复层级关系
-
-        Args:
-            patch_replies: 回复列表（应该已经按时间正序排序）
-            patch_message_id: PATCH 的 message_id
-
-        Returns:
-            回复层级结构
-        """
-        # 获取 session（从 repository）
-        session = self.feed_message_repo.session
-        return await build_reply_hierarchy_internal(
-            session, patch_replies, patch_message_id
-        )
-
     async def update_sub_patch_messages(
         self, thread_id: str, sub_patch_messages: dict
     ) -> bool:
@@ -452,35 +279,6 @@ class ThreadService:
         return await self.patch_thread_repo.update_sub_patch_messages(
             thread_id, sub_patch_messages
         )
-
-    async def _prepare_single_patch_overview(self, patch):
-        """为单个 Patch 准备 overview 数据
-
-        Args:
-            patch: Patch 对象（SeriesPatchInfo）
-
-        Returns:
-            SubPatchOverviewData 对象，失败返回 None
-        """
-        from .types import SubPatchOverviewData
-
-        try:
-            patch_replies = await self.get_all_replies_for_patch(patch.message_id)
-            patch_reply_hierarchy = await self.build_reply_hierarchy(
-                patch_replies, patch.message_id
-            )
-
-            return SubPatchOverviewData(
-                patch=patch,
-                replies=patch_replies,
-                reply_hierarchy=patch_reply_hierarchy,
-            )
-        except (RuntimeError, ValueError, AttributeError) as e:
-            logger.error(
-                f"Failed to prepare single patch overview: {e}",
-                exc_info=True,
-            )
-            return None
 
     async def get_all_replies_for_patch(
         self, patch_message_id: str
@@ -539,14 +337,132 @@ class ThreadService:
             )
             return []
 
+    async def _get_all_messages_for_series(
+        self, patch_card: PatchCard
+    ) -> List[FeedMessage]:
+        """获取 series 的所有消息（Cover Letter、子 patches、所有回复）
+
+        Args:
+            patch_card: PatchCard 对象（包含 series_patches 信息）
+
+        Returns:
+            所有相关消息的列表
+        """
+        all_messages: List[FeedMessage] = []
+        seen_message_ids: set = set()
+
+        # 收集所有需要查找回复的 message_id
+        message_ids_to_collect = []
+
+        # 添加 Cover Letter / 根消息
+        message_ids_to_collect.append(patch_card.message_id_header)
+
+        # 添加所有子 patches
+        if patch_card.series_patches:
+            for sub_patch in patch_card.series_patches:
+                if sub_patch.message_id not in seen_message_ids:
+                    message_ids_to_collect.append(sub_patch.message_id)
+
+        # 对每个消息收集其所有回复
+        for msg_id in message_ids_to_collect:
+            # 获取该消息本身
+            msg_data = await self.feed_message_repo.find_by_message_id_header(msg_id)
+            if msg_data and msg_id not in seen_message_ids:
+                all_messages.append(self._repo_data_to_service_feed_message(msg_data))
+                seen_message_ids.add(msg_id)
+
+            # 获取该消息的所有回复
+            replies = await self.get_all_replies_for_patch(msg_id)
+            for reply in replies:
+                if reply.message_id_header not in seen_message_ids:
+                    all_messages.append(reply)
+                    seen_message_ids.add(reply.message_id_header)
+
+        return all_messages
+
+    def _build_thread_tree(
+        self,
+        root_message: FeedMessage,
+        all_messages: List[FeedMessage],
+        patch_card: PatchCard,
+    ) -> ThreadNode:
+        """构建完整的 Thread 层级树
+
+        Args:
+            root_message: 根消息（Cover Letter 或单 Patch）
+            all_messages: 所有相关消息列表
+            patch_card: PatchCard 对象
+
+        Returns:
+            ThreadNode 层级树根节点
+        """
+        # 构建消息映射 {message_id: FeedMessage}
+        message_map: Dict[str, FeedMessage] = {
+            msg.message_id_header: msg for msg in all_messages
+        }
+
+        # 构建子 patch message_id 集合
+        sub_patch_ids: set = set()
+        if patch_card.series_patches:
+            for sub_patch in patch_card.series_patches:
+                sub_patch_ids.add(sub_patch.message_id)
+
+        # 构建 {parent_id: [children]} 映射
+        children_map: Dict[str, List[FeedMessage]] = {}
+        for msg in all_messages:
+            if msg.message_id_header == root_message.message_id_header:
+                continue  # 跳过根消息
+
+            parent_id = _extract_message_id_from_header(msg.in_reply_to_header)
+
+            # 确定父节点
+            if parent_id and parent_id in message_map:
+                actual_parent = parent_id
+            elif msg.message_id_header in sub_patch_ids:
+                # 子 patch 直接挂在根节点下
+                actual_parent = root_message.message_id_header
+            else:
+                # 无法确定父节点，挂在根节点下
+                actual_parent = root_message.message_id_header
+
+            if actual_parent not in children_map:
+                children_map[actual_parent] = []
+            children_map[actual_parent].append(msg)
+
+        # 对每个父节点的子节点按时间排序
+        for _, children in children_map.items():
+            children.sort(key=lambda m: m.received_at or datetime.min)
+
+        def _determine_node_type(msg: FeedMessage) -> str:
+            """确定节点类型"""
+            if msg.message_id_header == root_message.message_id_header:
+                if patch_card.is_cover_letter:
+                    return "cover_letter"
+                return "sub_patch"  # 单 patch 作为 sub_patch 类型
+            if msg.message_id_header in sub_patch_ids:
+                return "sub_patch"
+            return "reply"
+
+        def _build_node(msg: FeedMessage) -> ThreadNode:
+            """递归构建节点"""
+            children_msgs = children_map.get(msg.message_id_header, [])
+            children_nodes = [_build_node(child) for child in children_msgs]
+            return ThreadNode(
+                message=msg,
+                children=children_nodes,
+                node_type=_determine_node_type(msg),
+            )
+
+        return _build_node(root_message)
+
     async def prepare_thread_overview_data(
         self, message_id_header: str, patch_card_service=None
     ) -> Optional[ThreadOverviewData]:
         """准备 Thread Overview 渲染数据（供 Plugins 层使用）
 
-        统一处理单 Patch 和 Series Patch：
-        - 单 Patch：为该 Patch 准备所有 REPLY 数据（包括 REPLY 的 REPLY）
-        - Series Patch：以子 Patch 为单位，每个子 Patch 和单 Patch 的逻辑一致
+        构建完整的 Thread 层级树：
+        - Series Patch: Cover Letter 为根，子 patches 和回复为子节点
+        - 单 Patch: 该 Patch 为根，所有回复为子节点
 
         Args:
             message_id_header: PATCH message_id_header（Cover Letter 或单 Patch）
@@ -556,19 +472,14 @@ class ThreadService:
             ThreadOverviewData，如果不存在返回 None
         """
         from ..db.database import get_patch_card_service
-        from .helpers import build_single_patch_info
-
-        # ThreadOverviewData 已在模块顶部导入
 
         try:
             # 1. 获取 PatchCard（包含 series_patches）
             if patch_card_service:
-                # 使用传入的 service（复用 session）
                 patch_card = await patch_card_service.get_patch_card_with_series_data(
                     message_id_header
                 )
             else:
-                # 创建新的 service（使用新的 session）
                 async with get_patch_card_service() as service:
                     patch_card = await service.get_patch_card_with_series_data(
                         message_id_header
@@ -578,35 +489,25 @@ class ThreadService:
                 logger.warning(f"PatchCard not found: {message_id_header}")
                 return None
 
-            # 2. 确定要处理的 Patch 列表
-            if patch_card.is_series_patch and patch_card.series_patches:
-                # Series Patch：处理所有子 Patch
-                patches_to_process = list(patch_card.series_patches)
-            else:
-                # 单 Patch：构建 SeriesPatchInfo 对象
-                single_patch = build_single_patch_info(patch_card)
-                patches_to_process = [single_patch]
-
-            if not patches_to_process:
-                logger.warning(
-                    f"No patches to process for message_id_header: {message_id_header}"
-                )
+            # 2. 获取根消息
+            root_msg_data = await self.feed_message_repo.find_by_message_id_header(
+                message_id_header
+            )
+            if not root_msg_data:
+                logger.warning(f"Root message not found: {message_id_header}")
                 return None
+            root_message = self._repo_data_to_service_feed_message(root_msg_data)
 
-            # 3. 为每个 Patch 准备独立的 overview 数据
-            sub_patch_overviews = []
-            for patch in patches_to_process:
-                overview = await self._prepare_single_patch_overview(patch)
-                if overview:
-                    sub_patch_overviews.append(overview)
+            # 3. 获取所有相关消息
+            all_messages = await self._get_all_messages_for_series(patch_card)
 
-            # 4. 构建 ThreadOverviewData
-            # 注意：replies 和 reply_hierarchy 字段保留用于兼容，但实际使用 sub_patch_overviews
+            # 4. 构建层级树
+            root_node = self._build_thread_tree(root_message, all_messages, patch_card)
+
+            # 5. 返回 ThreadOverviewData（使用新的 root 字段）
             return ThreadOverviewData(
                 patch_card=patch_card,
-                replies=[],  # 不再使用整体 replies
-                reply_hierarchy=None,  # 不再使用整体 reply_hierarchy
-                sub_patch_overviews=sub_patch_overviews,
+                root=root_node,
             )
 
         except (RuntimeError, ValueError, AttributeError) as e:

--- a/src/lkml/service/types.py
+++ b/src/lkml/service/types.py
@@ -49,6 +49,10 @@ class PatchCard:
     to_cc_list: Optional[List[str]] = (
         None  # To 和 CC 列表（从 root patch 抓取，合并去重）
     )
+    content: Optional[str] = None  # 正文内容（用于渲染摘要）
+    summary: Optional[str] = None  # AI 生成的一句话摘要
+    received_at: Optional[datetime] = None  # 真正的接收时间
+    author_email: Optional[str] = None  # 作者邮箱
 
     # 渲染相关字段（供 Plugins 层使用）
     series_patches: Optional[List[SeriesPatchInfo]] = (

--- a/src/lkml/service/types.py
+++ b/src/lkml/service/types.py
@@ -6,7 +6,8 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict
+
 
 # 类型别名：在运行时导入实际模型，供 plugins 层使用
 # 这样 plugins 层就不需要直接依赖 lkml.db.models
@@ -93,47 +94,22 @@ class PatchThread:
     thread_id: str
     thread_name: str
     is_active: bool = True
-    sub_patch_messages: Optional[Dict[int, str]] = None  # {patch_index: message_id}
     overview_message_id: Optional[str] = None
+    sub_patch_messages: Optional[Dict[str, str]] = None
     created_at: Optional[datetime] = None
     archived_at: Optional[datetime] = None
 
 
 @dataclass
-class ReplyMapEntry:
-    """回复映射条目
+class ThreadNode:
+    """Thread 层级树节点
 
-    表示回复层级结构中的一个节点
+    表示邮件讨论树中的一个节点
     """
 
-    reply: Any  # FeedMessage 对象
-    children: List[str]  # 子回复的 message_id_header 列表
-
-
-@dataclass
-class ReplyHierarchy:
-    """回复层级结构
-
-    表示 PATCH 的所有回复的层级关系
-    """
-
-    reply_map: Dict[str, ReplyMapEntry]  # {message_id: ReplyMapEntry}
-    root_replies: List[str]  # 根回复的 message_id_header 列表
-
-
-@dataclass
-class SubPatchOverviewData:
-    """单个子 PATCH 的 Overview 数据（供 Plugins 层渲染使用）
-
-    包含渲染单个子 PATCH 所需的完整数据：
-    - PATCH 信息
-    - 该 PATCH 的所有回复（包括直接和间接回复）
-    - 回复层级结构（基于该 PATCH 的回复构建）
-    """
-
-    patch: SeriesPatchInfo  # 子 PATCH 信息
-    replies: List[FeedMessage]  # 该 PATCH 的所有回复列表
-    reply_hierarchy: ReplyHierarchy  # 该 PATCH 的回复层级结构
+    message: "FeedMessage"  # 消息内容
+    children: List["ThreadNode"]  # 子节点列表
+    node_type: str  # "cover_letter" | "sub_patch" | "reply"
 
 
 @dataclass
@@ -144,8 +120,4 @@ class ThreadOverviewData:
     """
 
     patch_card: PatchCard  # PatchCard 信息（包含 series_patches）
-    replies: List[FeedMessage]  # 所有回复列表
-    reply_hierarchy: ReplyHierarchy  # 回复层级结构
-    sub_patch_overviews: Optional[List[SubPatchOverviewData]] = (
-        None  # 每个子 PATCH 的独立 overview 数据（Series Patch 时使用）
-    )
+    root: Optional["ThreadNode"] = None  # 完整层级树

--- a/src/plugins/lkml_bot/__init__.py
+++ b/src/plugins/lkml_bot/__init__.py
@@ -127,10 +127,18 @@ async def send_update_callback(subsystem: str, update_data):
 # 创建 FeedMessageService（使用统一的多平台发送服务）
 # pylint: disable=wrong-import-position,wrong-import-order
 from lkml.service.feed_message_service import FeedMessageService
+from lkml.service.summarizer import ContentSummarizer
+
+content_summarizer = (  # pylint: disable=invalid-name
+    ContentSummarizer(plugin_config.gemini_api_key)
+    if plugin_config.gemini_api_key
+    else None
+)
 
 feed_message_service = FeedMessageService(
     patch_card_sender=patch_card_sender,
     thread_sender=thread_sender,
+    summarizer=content_summarizer,
 )
 
 processor = FeedProcessor(

--- a/src/plugins/lkml_bot/client/base.py
+++ b/src/plugins/lkml_bot/client/base.py
@@ -93,7 +93,12 @@ class ThreadClient(ABC):
 
     @abstractmethod
     async def send_thread_update_notification(
-        self, channel_id: str, thread_id: str, platform_message_id: Optional[str] = None
+        self,
+        channel_id: str,
+        thread_id: str,
+        platform_message_id: Optional[str] = None,
+        reply_author: str = "",
+        reply_summary: str = "",
     ) -> bool:
         """发送 Thread 更新通知
 
@@ -101,6 +106,8 @@ class ThreadClient(ABC):
             channel_id: 频道 ID
             thread_id: Thread ID
             platform_message_id: Patch Card 的消息 ID（可选）
+            reply_author: 回复者名称
+            reply_summary: 回复的 AI 摘要
 
         Returns:
             成功返回 True，失败返回 False

--- a/src/plugins/lkml_bot/client/base.py
+++ b/src/plugins/lkml_bot/client/base.py
@@ -98,7 +98,11 @@ class ThreadClient(ABC):
         thread_id: str,
         platform_message_id: Optional[str] = None,
         reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
         reply_summary: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> bool:
         """发送 Thread 更新通知
 
@@ -107,7 +111,11 @@ class ThreadClient(ABC):
             thread_id: Thread ID
             platform_message_id: Patch Card 的消息 ID（可选）
             reply_author: 回复者名称
+            reply_author_email: 回复者邮箱
+            reply_date: 回复日期字符串
             reply_summary: 回复的 AI 摘要
+            reply_url: 回复在 lore.kernel.org 上的链接
+            reply_content: 回复的原始内容（用于 fallback 摘要）
 
         Returns:
             成功返回 True，失败返回 False

--- a/src/plugins/lkml_bot/client/discord_client.py
+++ b/src/plugins/lkml_bot/client/discord_client.py
@@ -7,6 +7,8 @@
 Discord 的唯一客户端实例使用。
 """
 
+# pylint: disable=too-many-lines
+
 import asyncio
 from typing import Dict, List, Optional, Tuple
 
@@ -626,15 +628,19 @@ async def check_thread_exists(config, thread_id: str) -> bool:
         return False
 
 
-async def send_thread_update_notification(  # pylint: disable=too-many-arguments
+async def send_thread_update_notification(  # pylint: disable=too-many-arguments,too-many-locals
     config,
     channel_id: str,
     thread_id: str,
     platform_message_id: Optional[str] = None,  # pylint: disable=unused-argument
     reply_author: str = "",
+    reply_author_email: str = "",
+    reply_date: str = "",
     reply_summary: str = "",
+    reply_url: str = "",
+    reply_content: str = "",
 ) -> bool:
-    """发送 Thread 更新通知到频道（包含回复者和摘要信息）"""
+    """发送 Thread 更新通知到频道（embed 格式，包含回复者和摘要信息）"""
     try:
         if not config.discord_bot_token:
             logger.error("Discord bot token not configured")
@@ -645,20 +651,39 @@ async def send_thread_update_notification(  # pylint: disable=too-many-arguments
             "Content-Type": "application/json",
         }
 
-        # 使用 Thread 提及格式 <#{thread_id}>
-        thread_mention = f"Thread: <#{thread_id}>"
+        from ..renders.helpers import build_author_display, build_content_excerpt
 
-        # 构建通知消息：包含回复者和摘要
-        lines = [f"💬 **New Reply** in {thread_mention}"]
+        # content: thread 提及（embed 内不支持 channel mention）
+        content = f"Thread: <#{thread_id}>"
+
+        # 构建 embed description
+        desc_lines = []
+
+        # From / Date 行
         if reply_author:
-            # 取作者名称部分（去掉邮箱后缀）
-            author_name = reply_author.split(" (", 1)[0].split(" <", 1)[0]
-            lines.append(f"**From:** {author_name}")
-        if reply_summary:
-            lines.append(f"> {reply_summary}")
-        content = "\n".join(lines)
+            author_display = build_author_display(reply_author, reply_author_email)
+            desc_lines.append(f"**From:** {author_display}")
+        if reply_date:
+            desc_lines.append(f"**Date:** {reply_date}")
 
-        message_data = {"content": content}
+        # 摘要优先用 AI summary，fallback 到 content excerpt
+        summary_text = reply_summary
+        if not summary_text and reply_content:
+            summary_text = build_content_excerpt(reply_content, quote_prefix="")
+        if summary_text:
+            desc_lines.append(f"\n> {summary_text}")
+
+        # reply URL 链接
+        if reply_url:
+            desc_lines.append(f"\n🔗 [View Reply]({reply_url})")
+
+        embed = {
+            "title": "💬 New Reply",
+            "description": "\n".join(desc_lines),
+            "color": 0x5865F2,
+        }
+
+        message_data = {"content": content, "embeds": [embed]}
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -974,7 +999,11 @@ class DiscordClient(
         thread_id: str,
         platform_message_id: Optional[str] = None,
         reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
         reply_summary: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> bool:
         """发送 Thread 更新通知到频道"""
         return await send_thread_update_notification(
@@ -983,5 +1012,9 @@ class DiscordClient(
             thread_id,
             platform_message_id,
             reply_author=reply_author,
+            reply_author_email=reply_author_email,
+            reply_date=reply_date,
             reply_summary=reply_summary,
+            reply_url=reply_url,
+            reply_content=reply_content,
         )

--- a/src/plugins/lkml_bot/client/discord_client.py
+++ b/src/plugins/lkml_bot/client/discord_client.py
@@ -27,14 +27,7 @@ DISCORD_CONTENT_MAX_LENGTH = 2000
 
 
 def truncate_description(description: str) -> str:
-    """截断描述以符合 Discord embed 限制
-
-    Args:
-        description: 原始描述
-
-    Returns:
-        截断后的描述
-    """
+    """截断描述以符合 Discord embed 限制"""
     if len(description) > DISCORD_EMBED_DESCRIPTION_MAX_LENGTH:
         logger.warning(
             f"Description too long ({len(description)} chars), truncating to {DISCORD_EMBED_DESCRIPTION_MAX_LENGTH}"
@@ -633,23 +626,15 @@ async def check_thread_exists(config, thread_id: str) -> bool:
         return False
 
 
-async def send_thread_update_notification(
+async def send_thread_update_notification(  # pylint: disable=too-many-arguments
     config,
     channel_id: str,
     thread_id: str,
     platform_message_id: Optional[str] = None,  # pylint: disable=unused-argument
+    reply_author: str = "",
+    reply_summary: str = "",
 ) -> bool:
-    """发送 Thread 更新通知到频道
-
-    Args:
-        config: 配置对象
-        channel_id: 频道 ID
-        thread_id: Thread ID
-        platform_message_id: Patch Card 的消息 ID（用于构建 Thread 链接）
-
-    Returns:
-        成功返回 True，失败返回 False
-    """
+    """发送 Thread 更新通知到频道（包含回复者和摘要信息）"""
     try:
         if not config.discord_bot_token:
             logger.error("Discord bot token not configured")
@@ -663,8 +648,15 @@ async def send_thread_update_notification(
         # 使用 Thread 提及格式 <#{thread_id}>
         thread_mention = f"Thread: <#{thread_id}>"
 
-        # 构建通知消息
-        content = f"🔄 **Thread Overview 已更新**\n\n{thread_mention}\n\n"
+        # 构建通知消息：包含回复者和摘要
+        lines = [f"💬 **New Reply** in {thread_mention}"]
+        if reply_author:
+            # 取作者名称部分（去掉邮箱后缀）
+            author_name = reply_author.split(" (", 1)[0].split(" <", 1)[0]
+            lines.append(f"**From:** {author_name}")
+        if reply_summary:
+            lines.append(f"> {reply_summary}")
+        content = "\n".join(lines)
 
         message_data = {"content": content}
 
@@ -703,18 +695,7 @@ async def send_message_to_thread(
     embed: Optional[Dict] = None,
     max_retries: int = 3,
 ) -> Optional[str]:
-    """发送消息到 Thread（带 rate limit 处理）
-
-    Args:
-        config: 配置对象
-        thread_id: Thread ID
-        content: 消息内容
-        embed: 可选的 embed 字典
-        max_retries: 遇到 429 时的最大重试次数
-
-    Returns:
-        成功返回消息 ID，失败返回 None
-    """
+    """发送消息到 Thread（带 rate limit 处理）"""
     try:
         if not config.discord_bot_token:
             logger.error("Discord bot token not configured")
@@ -988,9 +969,19 @@ class DiscordClient(
         )
 
     async def send_thread_update_notification(
-        self, channel_id: str, thread_id: str, platform_message_id: Optional[str] = None
+        self,
+        channel_id: str,
+        thread_id: str,
+        platform_message_id: Optional[str] = None,
+        reply_author: str = "",
+        reply_summary: str = "",
     ) -> bool:
         """发送 Thread 更新通知到频道"""
         return await send_thread_update_notification(
-            self.config, channel_id, thread_id, platform_message_id
+            self.config,
+            channel_id,
+            thread_id,
+            platform_message_id,
+            reply_author=reply_author,
+            reply_summary=reply_summary,
         )

--- a/src/plugins/lkml_bot/client/feishu_client.py
+++ b/src/plugins/lkml_bot/client/feishu_client.py
@@ -163,17 +163,13 @@ class FeishuClient(
         )
 
     async def send_thread_update_notification(
-        self, channel_id: str, thread_id: str, platform_message_id: Optional[str] = None
+        self,
+        channel_id: str,
+        thread_id: str,
+        platform_message_id: Optional[str] = None,
+        reply_author: str = "",
+        reply_summary: str = "",
     ) -> bool:
-        """发送 Thread 更新通知（Feishu 不支持，直接返回 True）
-
-        Args:
-            channel_id: 频道 ID（未使用）
-            thread_id: Thread ID（未使用）
-            platform_message_id: 消息 ID（未使用）
-
-        Returns:
-            总是返回 True（Feishu 不支持此功能）
-        """
+        """发送 Thread 更新通知（Feishu 不支持，直接返回 True）"""
         # Feishu 不支持 Thread 更新通知，直接返回 True
         return True

--- a/src/plugins/lkml_bot/client/feishu_client.py
+++ b/src/plugins/lkml_bot/client/feishu_client.py
@@ -168,7 +168,11 @@ class FeishuClient(
         thread_id: str,
         platform_message_id: Optional[str] = None,
         reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
         reply_summary: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> bool:
         """发送 Thread 更新通知（Feishu 不支持，直接返回 True）"""
         # Feishu 不支持 Thread 更新通知，直接返回 True

--- a/src/plugins/lkml_bot/config.py
+++ b/src/plugins/lkml_bot/config.py
@@ -55,6 +55,7 @@ class PluginConfig(BaseLKMLConfig):
             max_news_count=base_config.max_news_count,
             monitoring_interval=base_config.monitoring_interval,
             last_update_dt_override_iso=base_config.last_update_dt_override_iso,
+            gemini_api_key=base_config.gemini_api_key,
             discord_webhook_url=discord_webhook_url,
             discord_bot_token=discord_bot_token,
             platform_channel_id=platform_channel_id,

--- a/src/plugins/lkml_bot/multi_platform_thread_sender.py
+++ b/src/plugins/lkml_bot/multi_platform_thread_sender.py
@@ -144,7 +144,12 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         return success
 
     async def send_thread_update_notification(
-        self, channel_id: str, thread_id: str, platform_message_id: Optional[str] = None
+        self,
+        channel_id: str,
+        thread_id: str,
+        platform_message_id: Optional[str] = None,
+        reply_author: str = "",
+        reply_summary: str = "",
     ) -> bool:
         """发送 Thread 更新通知
 
@@ -152,11 +157,17 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             channel_id: 频道 ID
             thread_id: Thread ID
             platform_message_id: Patch Card 消息 ID（可选）
+            reply_author: 回复者名称
+            reply_summary: 回复的 AI 摘要
 
         Returns:
             成功返回 True，失败返回 False
         """
         # 只由 Discord 发送（Feishu 不支持）
         return await self.discord_client.send_thread_update_notification(
-            channel_id, thread_id, platform_message_id
+            channel_id,
+            thread_id,
+            platform_message_id,
+            reply_author=reply_author,
+            reply_summary=reply_summary,
         )

--- a/src/plugins/lkml_bot/multi_platform_thread_sender.py
+++ b/src/plugins/lkml_bot/multi_platform_thread_sender.py
@@ -41,7 +41,11 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         self.feishu_renderer = feishu_renderer
 
     async def create_thread_and_send_overview(
-        self, thread_name: str, message_id: str, overview_data: ThreadOverviewData
+        self,
+        thread_name: str,
+        message_id: str,
+        overview_data: ThreadOverviewData,
+        skip_feishu_create: bool = False,
     ) -> Tuple[Optional[str], Dict[int, str]]:
         """创建 Thread 并发送 Overview
 
@@ -49,6 +53,7 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             thread_name: Thread 名称
             message_id: Patch Card 消息 ID（用于创建 Thread）
             overview_data: Thread Overview 数据
+            skip_feishu_create: 跳过 Feishu 创建通知（auto-watch 时 Patch Card 已包含信息）
 
         Returns:
             (thread_id, sub_patch_messages) 元组
@@ -84,14 +89,17 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
                 exc_info=True,
             )
 
-        # 2) Feishu：发送 Thread 创建通知卡片
-        try:
-            feishu_rendered = self.feishu_renderer.render_create_notification(
-                overview_data
-            )
-            await self.feishu_client.send_thread_overview("", feishu_rendered)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning("Error sending Feishu thread creation notification: %s", e)
+        # 2) Feishu：发送 Thread 创建通知卡片（auto-watch 时跳过，Patch Card 已包含信息）
+        if not skip_feishu_create:
+            try:
+                feishu_rendered = self.feishu_renderer.render_create_notification(
+                    overview_data
+                )
+                await self.feishu_client.send_thread_overview("", feishu_rendered)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    "Error sending Feishu thread creation notification: %s", e
+                )
 
         return thread_id, sub_patch_messages
 

--- a/src/plugins/lkml_bot/multi_platform_thread_sender.py
+++ b/src/plugins/lkml_bot/multi_platform_thread_sender.py
@@ -100,6 +100,7 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         thread_id: str,
         message_id: str,
         overview_data: ThreadOverviewData,
+        reply_summary: str = "",
     ) -> bool:
         """更新 Thread Overview
 
@@ -107,6 +108,7 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             thread_id: Discord Thread ID
             message_id: 要更新的消息 ID
             overview_data: Thread Overview 数据
+            reply_summary: Reply 的 AI 摘要（可选）
 
         Returns:
             成功返回 True，失败返回 False
@@ -133,7 +135,7 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         # 2) Feishu：发送 Thread 更新通知卡片
         try:
             feishu_rendered = self.feishu_renderer.render_update_notification(
-                overview_data
+                overview_data, reply_summary=reply_summary
             )
             await self.feishu_client.update_thread_overview("", "", feishu_rendered)
         except Exception as e:  # pylint: disable=broad-except

--- a/src/plugins/lkml_bot/multi_platform_thread_sender.py
+++ b/src/plugins/lkml_bot/multi_platform_thread_sender.py
@@ -101,6 +101,11 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         message_id: str,
         overview_data: ThreadOverviewData,
         reply_summary: str = "",
+        reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> bool:
         """更新 Thread Overview
 
@@ -109,6 +114,11 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             message_id: 要更新的消息 ID
             overview_data: Thread Overview 数据
             reply_summary: Reply 的 AI 摘要（可选）
+            reply_author: 回复者名称
+            reply_author_email: 回复者邮箱
+            reply_date: 回复日期字符串
+            reply_url: 回复在 lore.kernel.org 上的链接
+            reply_content: 回复的原始内容（用于 fallback 摘要）
 
         Returns:
             成功返回 True，失败返回 False
@@ -135,7 +145,13 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         # 2) Feishu：发送 Thread 更新通知卡片
         try:
             feishu_rendered = self.feishu_renderer.render_update_notification(
-                overview_data, reply_summary=reply_summary
+                overview_data,
+                reply_summary=reply_summary,
+                reply_author=reply_author,
+                reply_author_email=reply_author_email,
+                reply_date=reply_date,
+                reply_url=reply_url,
+                reply_content=reply_content,
             )
             await self.feishu_client.update_thread_overview("", "", feishu_rendered)
         except Exception as e:  # pylint: disable=broad-except
@@ -149,7 +165,11 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
         thread_id: str,
         platform_message_id: Optional[str] = None,
         reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
         reply_summary: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> bool:
         """发送 Thread 更新通知
 
@@ -158,7 +178,11 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             thread_id: Thread ID
             platform_message_id: Patch Card 消息 ID（可选）
             reply_author: 回复者名称
+            reply_author_email: 回复者邮箱
+            reply_date: 回复日期字符串
             reply_summary: 回复的 AI 摘要
+            reply_url: 回复在 lore.kernel.org 上的链接
+            reply_content: 回复的原始内容（用于 fallback 摘要）
 
         Returns:
             成功返回 True，失败返回 False
@@ -169,5 +193,9 @@ class MultiPlatformThreadSender:  # pylint: disable=too-few-public-methods
             thread_id,
             platform_message_id,
             reply_author=reply_author,
+            reply_author_email=reply_author_email,
+            reply_date=reply_date,
             reply_summary=reply_summary,
+            reply_url=reply_url,
+            reply_content=reply_content,
         )

--- a/src/plugins/lkml_bot/renders/helpers.py
+++ b/src/plugins/lkml_bot/renders/helpers.py
@@ -1,0 +1,200 @@
+"""渲染辅助函数
+
+提供 Discord / Feishu 渲染器共用的内容处理工具函数。
+"""
+
+import re
+from html.parser import HTMLParser
+
+# 需要跳过的 commit trailer 前缀（纯元数据，非正文内容）
+_SKIP_TRAILER_PREFIXES = (
+    "Signed-off-by:",
+    "Cc:",
+    "Link:",
+    "Message-Id:",
+    "Message-ID:",
+    "Fixes:",
+    "Co-developed-by:",
+)
+
+# diff 相关行前缀
+_DIFF_PREFIXES = ("diff --git ", "index ", "--- a/", "+++ b/", "@@ ")
+
+
+class _HTMLStripper(HTMLParser):
+    """HTML 标签剥离器"""
+
+    def __init__(self):
+        super().__init__()
+        self.parts: list[str] = []
+
+    def handle_data(self, data):
+        """收集纯文本内容"""
+        self.parts.append(data)
+
+    def get_text(self):
+        """返回拼接后的纯文本"""
+        return "".join(self.parts)
+
+
+def strip_html_tags(html: str) -> str:
+    """去除 HTML 标签，保留纯文本内容"""
+    stripper = _HTMLStripper()
+    stripper.feed(html)
+    return stripper.get_text()
+
+
+def clean_email_content(content: str) -> str:
+    """清洗邮件原始内容，提炼出人写的描述部分
+
+    过滤规则（按行）：
+    - 去掉引用行（> ...）
+    - 去掉 diff / diffstat / 代码 hunk
+    - 遇到 "---" 分隔线即停止（后续是 diffstat / diff）
+    - 去掉 commit trailer（Signed-off-by 等元数据）
+    - 去掉 "On ... wrote:" 邮件引用头
+    - 折叠连续空行
+    """
+    content = strip_html_tags(content)
+    lines = content.split("\n")
+    cleaned: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # "---" 独立行是 patch 正文和 diffstat 的分隔线，后续全是代码
+        if stripped == "---":
+            break
+
+        # 跳过引用行
+        if stripped.startswith(">"):
+            continue
+
+        # 跳过 diff 头 / hunk 头
+        if stripped.startswith(_DIFF_PREFIXES):
+            continue
+
+        # 跳过 diff hunk 内容行（+/- 开头，但不是 "---" 或 "+++" 已处理）
+        if re.match(r"^[+-][^+-]", stripped):
+            continue
+
+        # 跳过 diffstat 行：  file.c | 10 ++++---
+        if re.match(r"^\s*\S+\s+\|\s+\d+", stripped):
+            continue
+
+        # 跳过 diffstat 汇总行：  3 files changed, 10 insertions(+)
+        if re.match(r"^\s*\d+ files? changed", stripped):
+            continue
+
+        # 跳过 commit trailer
+        if stripped.startswith(_SKIP_TRAILER_PREFIXES):
+            continue
+
+        # 跳过邮件引用头 "On Mon, Jan 28 ... wrote:"
+        if re.match(r"^On .+ wrote:\s*$", stripped):
+            continue
+
+        cleaned.append(line)
+
+    # 折叠连续空行
+    result = "\n".join(cleaned)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result.strip()
+
+
+def build_author_display(name: str, email: str = "") -> str:
+    """构建 Author 显示：Name <email>，相同则只显示一个
+
+    自动处理 lore.kernel.org 常见的 "Name (email)" 格式，
+    避免与单独传入的 email 参数产生重复。
+    """
+    # lore.kernel.org 格式: "Name (email@example.com)" → 拆分
+    if " (" in name and name.endswith(")"):
+        paren_content = name.rsplit(" (", 1)[1][:-1]
+        name = name.rsplit(" (", 1)[0]
+        if not email and "@" in paren_content:
+            email = paren_content
+    if email and email != name:
+        return f"{name} <{email}>"
+    return name or email or "Unknown"
+
+
+def build_content_excerpt(
+    content: str,
+    max_length: int = 200,
+    max_lines: int = 4,
+    max_line_len: int = 80,
+    quote_prefix: str = "> ",
+) -> str:
+    """清洗内容并构建摘要（引用块格式）
+
+    先清洗噪音，再按行截断 + 总长截断。
+
+    Args:
+        content: 原始邮件正文
+        max_length: 总字符上限
+        max_lines: 最大行数
+        max_line_len: 单行字符上限
+        quote_prefix: 每行前缀（引用标记）
+    """
+    text = clean_email_content(content)
+    if not text:
+        return ""
+
+    raw_lines = text.split("\n")[:max_lines]
+    trimmed_lines: list[str] = []
+    total = 0
+
+    for line in raw_lines:
+        if total >= max_length:
+            break
+        if len(line) > max_line_len:
+            line = line[:max_line_len] + "..."
+        remaining = max_length - total
+        if len(line) > remaining:
+            line = line[:remaining].rsplit(" ", 1)[0] + "..."
+        trimmed_lines.append(line)
+        total += len(line)
+
+    if not trimmed_lines:
+        return ""
+
+    # 内容被截断时追加省略号
+    if total >= max_length or len(raw_lines) < len(text.split("\n")):
+        last = trimmed_lines[-1]
+        if not last.endswith("..."):
+            trimmed_lines[-1] = last + "..."
+
+    return "\n".join(f"{quote_prefix}{line}" for line in trimmed_lines)
+
+
+def build_cc_summary(
+    cc_list: list[str], max_show: int = 3, max_total_len: int = 120
+) -> str:
+    """构建 CC 列表缩略显示
+
+    限制展示数量和总长度，避免 CC 列表过长。
+    """
+    if not cc_list:
+        return ""
+
+    shown: list[str] = []
+    total_len = 0
+
+    for addr in cc_list[:max_show]:
+        if len(addr) > 40:
+            addr = addr[:37] + "..."
+        if total_len + len(addr) > max_total_len:
+            break
+        shown.append(addr)
+        total_len += len(addr) + 2  # ", " separator
+
+    if not shown:
+        first = cc_list[0]
+        shown.append(first[:37] + "..." if len(first) > 40 else first)
+
+    remaining = len(cc_list) - len(shown)
+    result = "**CC:** " + ", ".join(shown)
+    if remaining > 0:
+        result += f" (+{remaining} more)"
+    return result

--- a/src/plugins/lkml_bot/renders/patch_card/feishu_render.py
+++ b/src/plugins/lkml_bot/renders/patch_card/feishu_render.py
@@ -2,6 +2,7 @@
 
 from lkml.service import PatchCard
 
+from ..helpers import build_author_display, build_cc_summary, build_content_excerpt
 from ..types import FeishuRenderedPatchCard
 
 
@@ -21,12 +22,6 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
             FeishuRenderedPatchCard 渲染结果
         """
         header_title = patch_card.subject[:200]
-        date_str = (
-            patch_card.expires_at.strftime("%Y-%m-%d %H:%M UTC")
-            if patch_card.expires_at
-            else ""
-        )
-        author_str = patch_card.author or "Unknown"
 
         # 是否为系列 PATCH（Single Patch 时不显示 Series 信息）
         is_series = bool(
@@ -39,20 +34,7 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
             patch_card, is_series
         )
 
-        # 基础信息（Single Patch / Series 共用）
-        base_content_lines = [
-            f"• **Subsystem** ：{patch_card.subsystem_name}",
-            f"• **Date** ：{date_str}",
-            f"• **Author** ：{author_str}",
-        ]
-
-        # 只有系列 PATCH 时才显示统计信息
-        if is_series:
-            total_patches = patch_card.patch_total or 0
-            base_content_lines.append(f"• **Total Patches** ：{total_patches}")
-            base_content_lines.append(f"• **Received** ：{received}/{total_patches}")
-
-        base_content = "\n".join(base_content_lines)
+        base_content = self._build_base_content(patch_card, is_series, received)
 
         card = {
             "msg_type": "interactive",
@@ -111,6 +93,38 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
                 "margin": "0px 0px 0px 0px",
             }
         ]
+
+        # Content excerpt（优先使用 AI 摘要，fallback 到规则截断）
+        content_text = None
+        if patch_card.summary:
+            content_text = f"> {patch_card.summary}"
+        elif patch_card.content:
+            content_text = build_content_excerpt(patch_card.content)
+
+        if content_text:
+            elements.append(
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": content_text,
+                    },
+                }
+            )
+
+        # CC 列表
+        if patch_card.to_cc_list:
+            cc_str = build_cc_summary(patch_card.to_cc_list)
+            if cc_str:
+                elements.append(
+                    {
+                        "tag": "div",
+                        "text": {
+                            "tag": "lark_md",
+                            "content": cc_str,
+                        },
+                    }
+                )
 
         # 只有系列 PATCH 时才添加 Series 模块
         if is_series and subpatch_md:
@@ -171,6 +185,30 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
 
         return FeishuRenderedPatchCard(card=card)
 
+    @staticmethod
+    def _build_base_content(
+        patch_card: PatchCard, is_series: bool, received: int
+    ) -> str:
+        """构建基础信息 Markdown 内容"""
+        date_value = patch_card.received_at or patch_card.expires_at
+        date_str = date_value.strftime("%Y-%m-%d %H:%M UTC") if date_value else ""
+
+        author_str = build_author_display(patch_card.author, patch_card.author_email)
+
+        lines = [
+            f"• **Subsystem** ：{patch_card.subsystem_name}",
+            f"• **Date** ：{date_str}",
+            f"• **Author** ：{author_str}",
+        ]
+        if patch_card.patch_version:
+            lines.append(f"• **Version** ：{patch_card.patch_version}")
+        if is_series:
+            total_patches = patch_card.patch_total or 0
+            lines.append(f"• **Total Patches** ：{total_patches}")
+            lines.append(f"• **Received** ：{received}/{total_patches}")
+
+        return "\n".join(lines)
+
     def _build_series_markdown_and_received(
         self, patch_card: PatchCard, is_series: bool
     ) -> tuple[str, int]:
@@ -224,13 +262,16 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
         """构建 Reply 通知的基础信息内容"""
         reply_subsystem = payload.get("reply_subsystem") or ""
         reply_date = payload.get("reply_date") or ""
+        reply_author_name = payload.get("reply_author_name") or ""
+
+        author_display = build_author_display(reply_author_name, reply_author)
 
         base_content_lines = []
         if reply_subsystem:
             base_content_lines.append(f"• **Subsystem** ：{reply_subsystem}")
         if reply_date:
             base_content_lines.append(f"• **Date** ：{reply_date}")
-        base_content_lines.append(f"• **Author** ：{reply_author}")
+        base_content_lines.append(f"• **Author** ：{author_display}")
 
         return "\n".join(base_content_lines)
 
@@ -238,6 +279,7 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
         """构建 Reply 通知的卡片元素列表"""
         reply_subject = payload.get("reply_subject") or ""
         reply_url = payload.get("reply_url")
+        reply_content = payload.get("reply_content") or ""
         root_subject = payload.get("root_subject") or ""
         root_url = payload.get("root_url")
 
@@ -271,7 +313,26 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
             }
         ]
 
-        # Reply Subject 和 Root Patch 显示在单独的区域
+        # Reply content（优先使用 AI 摘要，fallback 到规则截断）
+        reply_summary = payload.get("reply_summary")
+        content_text = None
+        if reply_summary:
+            content_text = f"> {reply_summary}"
+        elif reply_content:
+            content_text = build_content_excerpt(reply_content)
+
+        if content_text:
+            elements.append(
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": content_text,
+                    },
+                }
+            )
+
+        # Reply Subject 和 Root Patch 显示在单独的区域（措辞优化）
         if reply_subject:
             reply_subject_content = (
                 f"[{reply_subject}]({reply_url})" if reply_url else reply_subject
@@ -295,7 +356,7 @@ class FeishuPatchCardRenderer:  # pylint: disable=too-few-public-methods
                     "tag": "div",
                     "text": {
                         "tag": "lark_md",
-                        "content": f"**Root Patch:**\n{root_patch_content}",
+                        "content": f"**In reply to:**\n{root_patch_content}",
                     },
                 }
             )

--- a/src/plugins/lkml_bot/renders/patch_card/renderer.py
+++ b/src/plugins/lkml_bot/renders/patch_card/renderer.py
@@ -7,6 +7,7 @@ Plugins 层渲染器：只负责将 PatchCard 渲染成 Discord 格式。
 from lkml.service import PatchCard
 
 from ...client.discord_params import PatchCardParams
+from ..helpers import build_author_display, build_cc_summary, build_content_excerpt
 from ..types import DiscordRenderedPatchCard
 
 
@@ -54,7 +55,7 @@ class PatchCardRenderer:
             message_id_header=patch_card.message_id_header,
             subject=patch_card.subject,
             author=patch_card.author,
-            received_at=patch_card.expires_at,  # FIXME: 应该用 received_at
+            received_at=patch_card.received_at or patch_card.expires_at,
             url=patch_card.url,
             series_message_id=patch_card.series_message_id,
             patch_version=patch_card.patch_version,
@@ -72,7 +73,9 @@ class PatchCardRenderer:
             title=title,
         )
 
-    def _build_description(self, patch_card: PatchCard) -> str:
+    def _build_description(  # pylint: disable=too-many-branches
+        self, patch_card: PatchCard
+    ) -> str:
         """构建 Embed 描述（纯渲染逻辑）
 
         Args:
@@ -86,9 +89,16 @@ class PatchCardRenderer:
         # 基本信息（YAML 格式）
         lines.append("```yaml")
         lines.append(f"Subsystem: {patch_card.subsystem_name}")
-        if patch_card.expires_at:
-            lines.append(f"Date: {patch_card.expires_at.strftime('%Y-%m-%d %H:%M:%S')}")
-        lines.append(f"Author: {patch_card.author}")
+        date_value = patch_card.received_at or patch_card.expires_at
+        if date_value:
+            lines.append(f"Date: {date_value.strftime('%Y-%m-%d %H:%M:%S')}")
+
+        author_str = build_author_display(patch_card.author, patch_card.author_email)
+        lines.append(f"Author: {author_str}")
+
+        # Version（有时才显示）
+        if patch_card.patch_version:
+            lines.append(f"Version: {patch_card.patch_version}")
 
         # 如果是系列，显示总数和已接收数
         if patch_card.is_series_patch and patch_card.patch_total:
@@ -99,6 +109,25 @@ class PatchCardRenderer:
             lines.append(f"Received: {received}/{patch_card.patch_total}")
 
         lines.append("```")
+
+        # Content excerpt（优先使用 AI 摘要，fallback 到规则截断）
+        if patch_card.summary:
+            lines.append(f"> {patch_card.summary}")
+        elif patch_card.content:
+            excerpt = build_content_excerpt(patch_card.content)
+            if excerpt:
+                lines.append(excerpt)
+
+        # CC 列表（缩略显示）
+        if patch_card.to_cc_list:
+            cc_str = build_cc_summary(patch_card.to_cc_list)
+            if cc_str:
+                lines.append(cc_str)
+
+        # 匹配的 filter 名称
+        if patch_card.matched_filters:
+            filters_str = ", ".join(patch_card.matched_filters)
+            lines.append(f"**Matched Filters:** {filters_str}")
 
         # 系列 PATCH 列表
         if patch_card.series_patches:
@@ -130,61 +159,68 @@ class PatchCardRenderer:
 
         Args:
             payload: Reply 通知数据
-                - reply_author: 回复作者
-                - reply_subject: 回复主题
-                - reply_url: 回复链接
-                - root_subject: 根 Patch 主题
-                - root_url: 根 Patch 链接
 
         Returns:
             DiscordRenderedReplyNotification 渲染结果
         """
         from ..types import DiscordRenderedReplyNotification
 
-        reply_author = payload.get("reply_author") or "unknown"
+        title = self._build_reply_title(payload)
+        description = self._build_reply_description(payload)
+
+        return DiscordRenderedReplyNotification(
+            title=title,
+            description=description,
+            url=payload.get("reply_url"),
+            embed_color=0x5865F2,
+        )
+
+    def _build_reply_title(self, payload: dict) -> str:
+        """构建 Reply 通知标题"""
         reply_subject = payload.get("reply_subject") or ""
-        reply_url = payload.get("reply_url")
+        reply_author = payload.get("reply_author") or "unknown"
+        if reply_subject:
+            return f"\U0001f4ac {reply_subject}"
+        return f"\U0001f4ac [Reply from {reply_author}]"
+
+    def _build_reply_description(self, payload: dict) -> str:
+        """构建 Reply 通知描述"""
+        reply_author = payload.get("reply_author") or "unknown"
+        reply_author_name = payload.get("reply_author_name") or ""
         reply_subsystem = payload.get("reply_subsystem") or ""
         reply_date = payload.get("reply_date") or ""
+        reply_content = payload.get("reply_content") or ""
         root_subject = payload.get("root_subject") or ""
         root_url = payload.get("root_url")
 
-        # 标题（使用 subject 名称，可点击链接）
-        if reply_subject:
-            title = reply_subject
-        else:
-            title = f"[Reply from {reply_author}]"
+        author_display = build_author_display(reply_author_name, reply_author)
 
         lines = []
 
-        # 信息框（YAML 格式，只显示 Subsystem、Date、Author - 都是 reply 的信息）
+        # 信息框（YAML 格式）
         lines.append("```yaml")
         if reply_subsystem:
             lines.append(f"Subsystem: {reply_subsystem}")
         if reply_date:
             lines.append(f"Date: {reply_date}")
-        lines.append(f"Author: {reply_author}")
+        lines.append(f"Author: {author_display}")
         lines.append("```")
 
-        # Reply Subject 和 Root Patch 显示在 YAML 模块外（换行显示）
-        if reply_subject:
-            lines.append("Reply Subject:")
-            if reply_url:
-                lines.append(f"[{reply_subject}]({reply_url})")
-            else:
-                lines.append(reply_subject)
+        # Reply content（优先使用 AI 摘要，fallback 到规则截断）
+        reply_summary = payload.get("reply_summary")
+        if reply_summary:
+            lines.append(f"> {reply_summary}")
+        elif reply_content:
+            excerpt = build_content_excerpt(reply_content)
+            if excerpt:
+                lines.append(excerpt)
+
+        # In reply to（措辞优化）
         if root_subject:
-            lines.append("Root Patch:")
+            lines.append("**In reply to:**")
             if root_url:
                 lines.append(f"[{root_subject}]({root_url})")
             else:
                 lines.append(root_subject)
 
-        description = "\n".join(lines)
-
-        return DiscordRenderedReplyNotification(
-            title=title,
-            description=description,
-            url=reply_url,
-            embed_color=0x5865F2,  # 蓝色（参考第一张图）
-        )
+        return "\n".join(lines)

--- a/src/plugins/lkml_bot/renders/thread/feishu_render.py
+++ b/src/plugins/lkml_bot/renders/thread/feishu_render.py
@@ -118,18 +118,76 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
         return FeishuRenderedThreadNotification(card=card)
 
     def render_update_notification(
-        self, overview_data: ThreadOverviewData
+        self, overview_data: ThreadOverviewData, reply_summary: str = ""
     ) -> FeishuRenderedThreadNotification:
         """渲染 Thread 更新通知卡片（不发送）
 
         Args:
             overview_data: 线程概览数据
+            reply_summary: Reply 的 AI 摘要（可选）
 
         Returns:
             FeishuRenderedThreadNotification 渲染结果
         """
         subj = overview_data.patch_card.subject[:200]
         link = overview_data.patch_card.url or ""
+
+        # 构建 elements 列表
+        elements = []
+
+        # AI 摘要块（有时才显示）
+        if reply_summary:
+            elements.append(
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-50",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": f"**AI Summary**\n{reply_summary}",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                }
+                            ],
+                            "padding": "12px 12px 12px 12px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1,
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px",
+                }
+            )
+
+        elements.append(
+            {
+                "tag": "button",
+                "text": {
+                    "tag": "plain_text",
+                    "content": "查看补丁详情",
+                },
+                "type": "primary_filled",
+                "width": "fill",
+                "behaviors": [
+                    {
+                        "type": "open_url",
+                        "default_url": link or "",
+                        "pc_url": "",
+                        "ios_url": "",
+                        "android_url": "",
+                    }
+                ],
+                "margin": "4px 0px 4px 0px",
+            },
+        )
 
         card = {
             "msg_type": "interactive",
@@ -154,27 +212,7 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
                 },
                 "body": {
                     "direction": "vertical",
-                    "elements": [
-                        {
-                            "tag": "button",
-                            "text": {
-                                "tag": "plain_text",
-                                "content": "查看补丁详情",
-                            },
-                            "type": "primary_filled",
-                            "width": "fill",
-                            "behaviors": [
-                                {
-                                    "type": "open_url",
-                                    "default_url": link or "",
-                                    "pc_url": "",
-                                    "ios_url": "",
-                                    "android_url": "",
-                                }
-                            ],
-                            "margin": "4px 0px 4px 0px",
-                        },
-                    ],
+                    "elements": elements,
                 },
             },
         }

--- a/src/plugins/lkml_bot/renders/thread/feishu_render.py
+++ b/src/plugins/lkml_bot/renders/thread/feishu_render.py
@@ -6,6 +6,7 @@
 
 from lkml.service.types import ThreadOverviewData
 
+from ..helpers import build_author_display
 from ..types import FeishuRenderedThreadNotification
 
 
@@ -15,7 +16,7 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
     def __init__(self, config):
         self.config = config  # 目前未使用，保留以便未来扩展
 
-    def render_create_notification(
+    def render_create_notification(  # pylint: disable=too-many-locals
         self, overview_data: ThreadOverviewData
     ) -> FeishuRenderedThreadNotification:
         """渲染 Thread 创建通知卡片（不发送）
@@ -26,16 +27,117 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
         Returns:
             FeishuRenderedThreadNotification 渲染结果
         """
-        subject = overview_data.patch_card.subject[:200]
-        patch_card_link = overview_data.patch_card.url or ""
+        pc = overview_data.patch_card
+        subject = pc.subject[:200]
+        patch_card_link = pc.url or ""
 
+        # 基本信息
+        date_value = pc.received_at or pc.expires_at
+        date_str = date_value.strftime("%Y-%m-%d %H:%M UTC") if date_value else ""
+        author_str = build_author_display(pc.author, pc.author_email)
+
+        base_content_lines = [
+            f"• **Subsystem** ：{pc.subsystem_name}",
+            f"• **Author** ：{author_str}",
+        ]
+        if date_str:
+            base_content_lines.append(f"• **Date** ：{date_str}")
+        base_content = "\n".join(base_content_lines)
+
+        # Series list
         lines = []
-        if overview_data.sub_patch_overviews:
-            for sp in overview_data.sub_patch_overviews:
-                subj = sp.patch.subject
-                link = sp.patch.url or ""
+        if pc.series_patches:
+            for sp in pc.series_patches:
+                subj = sp.subject
+                link = sp.url or ""
                 lines.append(f"  - [{subj}]({link}) ")
         sub_md = "\n".join(lines) if lines else ""
+
+        elements = [
+            # 基本信息块
+            {
+                "tag": "column_set",
+                "flex_mode": "stretch",
+                "horizontal_spacing": "8px",
+                "horizontal_align": "left",
+                "columns": [
+                    {
+                        "tag": "column",
+                        "width": "weighted",
+                        "background_style": "blue-50",
+                        "elements": [
+                            {
+                                "tag": "markdown",
+                                "content": base_content,
+                                "text_align": "left",
+                                "text_size": "normal",
+                            }
+                        ],
+                        "padding": "12px 12px 12px 12px",
+                        "vertical_spacing": "8px",
+                        "horizontal_align": "left",
+                        "vertical_align": "top",
+                        "weight": 1,
+                    }
+                ],
+                "margin": "0px 0px 0px 0px",
+            },
+        ]
+
+        # Series 列表块（有时才显示）
+        if sub_md:
+            elements.append(
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-50",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": ("• **Series** ：\n" + sub_md),
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                }
+                            ],
+                            "padding": "12px 12px 12px 12px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1,
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px",
+                }
+            )
+
+        # 查看详情按钮
+        elements.append(
+            {
+                "tag": "button",
+                "text": {
+                    "tag": "plain_text",
+                    "content": "查看补丁详情",
+                },
+                "type": "primary_filled",
+                "width": "fill",
+                "behaviors": [
+                    {
+                        "type": "open_url",
+                        "default_url": patch_card_link or "",
+                        "pc_url": "",
+                        "ios_url": "",
+                        "android_url": "",
+                    }
+                ],
+                "margin": "4px 0px 4px 0px",
+            }
+        )
 
         card = {
             "msg_type": "interactive",
@@ -63,80 +165,99 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
                 },
                 "body": {
                     "direction": "vertical",
-                    "elements": [
-                        {
-                            "tag": "column_set",
-                            "flex_mode": "stretch",
-                            "horizontal_spacing": "8px",
-                            "horizontal_align": "left",
-                            "columns": [
-                                {
-                                    "tag": "column",
-                                    "width": "weighted",
-                                    "background_style": "grey-50",
-                                    "elements": [
-                                        {
-                                            "tag": "markdown",
-                                            "content": ("• **Series** ：\n" + sub_md),
-                                            "text_align": "left",
-                                            "text_size": "normal",
-                                        }
-                                    ],
-                                    "padding": "12px 12px 12px 12px",
-                                    "vertical_spacing": "8px",
-                                    "horizontal_align": "left",
-                                    "vertical_align": "top",
-                                    "weight": 1,
-                                }
-                            ],
-                            "margin": "0px 0px 0px 0px",
-                        },
-                        {
-                            "tag": "button",
-                            "text": {
-                                "tag": "plain_text",
-                                "content": "查看补丁详情",
-                            },
-                            "type": "primary_filled",
-                            "width": "fill",
-                            "behaviors": [
-                                {
-                                    "type": "open_url",
-                                    "default_url": patch_card_link or "",
-                                    "pc_url": "",
-                                    "ios_url": "",
-                                    "android_url": "",
-                                }
-                            ],
-                            "margin": "4px 0px 4px 0px",
-                        },
-                    ],
+                    "elements": elements,
                 },
             },
         }
 
         return FeishuRenderedThreadNotification(card=card)
 
-    def render_update_notification(
-        self, overview_data: ThreadOverviewData, reply_summary: str = ""
+    def render_update_notification(  # pylint: disable=too-many-locals
+        self,
+        overview_data: ThreadOverviewData,
+        reply_summary: str = "",
+        reply_author: str = "",
+        reply_author_email: str = "",
+        reply_date: str = "",
+        reply_url: str = "",
+        reply_content: str = "",
     ) -> FeishuRenderedThreadNotification:
         """渲染 Thread 更新通知卡片（不发送）
 
         Args:
             overview_data: 线程概览数据
             reply_summary: Reply 的 AI 摘要（可选）
+            reply_author: 回复者名称
+            reply_author_email: 回复者邮箱
+            reply_date: 回复日期字符串
+            reply_url: 回复在 lore.kernel.org 上的链接
+            reply_content: 回复的原始内容（用于 fallback 摘要）
 
         Returns:
             FeishuRenderedThreadNotification 渲染结果
         """
-        subj = overview_data.patch_card.subject[:200]
-        link = overview_data.patch_card.url or ""
+        from ..helpers import build_content_excerpt
 
-        # 构建 elements 列表
-        elements = []
+        pc = overview_data.patch_card
+        subj = pc.subject[:200]
+        patch_link = pc.url or ""
 
-        # AI 摘要块（有时才显示）
-        if reply_summary:
+        # 使用调用方传入的回复信息，fallback 到层级树查找
+        if reply_author or reply_author_email:
+            author_display = build_author_display(reply_author, reply_author_email)
+            latest_url = ""
+        else:
+            author_display, latest_url = self._find_latest_reply_info(overview_data)
+
+        # 基本信息
+        info_lines = []
+        if author_display:
+            info_lines.append(f"• **Reply From** ：{author_display}")
+        if reply_date:
+            info_lines.append(f"• **Date** ：{reply_date}")
+
+        info_content = "\n".join(info_lines)
+
+        # 摘要：AI summary 优先，fallback 到 content excerpt
+        summary_text = reply_summary
+        if not summary_text and reply_content:
+            summary_text = build_content_excerpt(reply_content, quote_prefix="")
+
+        # 按钮优先跳转到 reply_url，fallback 到层级树 latest_url，再 fallback 到 patch
+        button_url = reply_url or latest_url or patch_link
+
+        elements = [
+            {
+                "tag": "column_set",
+                "flex_mode": "stretch",
+                "horizontal_spacing": "8px",
+                "horizontal_align": "left",
+                "columns": [
+                    {
+                        "tag": "column",
+                        "width": "weighted",
+                        "background_style": "blue-50",
+                        "elements": [
+                            {
+                                "tag": "markdown",
+                                "content": info_content,
+                                "text_align": "left",
+                                "text_size": "normal",
+                            }
+                        ],
+                        "padding": "12px 12px 12px 12px",
+                        "vertical_spacing": "8px",
+                        "horizontal_align": "left",
+                        "vertical_align": "top",
+                        "weight": 1,
+                    }
+                ],
+                "margin": "0px 0px 0px 0px",
+            },
+        ]
+
+        # 摘要块（AI summary 或 content excerpt，有内容时才显示）
+        if summary_text:
             elements.append(
                 {
                     "tag": "column_set",
@@ -151,7 +272,7 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
                             "elements": [
                                 {
                                     "tag": "markdown",
-                                    "content": f"**AI Summary**\n{reply_summary}",
+                                    "content": summary_text,
                                     "text_align": "left",
                                     "text_size": "normal",
                                 }
@@ -172,14 +293,14 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
                 "tag": "button",
                 "text": {
                     "tag": "plain_text",
-                    "content": "查看补丁详情",
+                    "content": "查看最新回复",
                 },
                 "type": "primary_filled",
                 "width": "fill",
                 "behaviors": [
                     {
                         "type": "open_url",
-                        "default_url": link or "",
+                        "default_url": button_url,
                         "pc_url": "",
                         "ios_url": "",
                         "android_url": "",
@@ -218,3 +339,38 @@ class FeishuThreadOverviewRenderer:  # pylint: disable=too-few-public-methods
         }
 
         return FeishuRenderedThreadNotification(card=card)
+
+    @staticmethod
+    def _find_latest_reply_info(
+        overview_data: ThreadOverviewData,
+    ) -> tuple[str, str]:
+        """从层级树中找到最新回复者名称和 URL
+
+        Returns:
+            (author, url) 元组，找不到时返回 ("", "")
+        """
+        if not overview_data.root:
+            return "", ""
+
+        # DFS 遍历树，找到最新的 reply 节点（按 received_at 排序）
+        from lkml.service.types import ThreadNode
+
+        latest_author = ""
+        latest_url = ""
+        latest_time = None
+
+        def _walk(node: ThreadNode):
+            nonlocal latest_author, latest_url, latest_time
+            if node.node_type == "reply":
+                msg = node.message
+                if msg.received_at and (
+                    latest_time is None or msg.received_at > latest_time
+                ):
+                    latest_time = msg.received_at
+                    latest_author = msg.author or ""
+                    latest_url = msg.url or ""
+            for child in node.children:
+                _walk(child)
+
+        _walk(overview_data.root)
+        return latest_author, latest_url

--- a/src/plugins/lkml_bot/renders/thread/renderer.py
+++ b/src/plugins/lkml_bot/renders/thread/renderer.py
@@ -118,7 +118,9 @@ class ThreadOverviewRenderer:
 
         # 格式化当前节点：` 时间 [subject](url) 作者
         subject = msg.subject.split("] ", 1)[0] + "]"
-        msg_time = msg.received_at.strftime("%Y-%m-%d %H:%M") if msg.received_at else ""
+        msg_time = (
+            msg.received_at.strftime("%Y-%m-%d %H:%M UTC") if msg.received_at else ""
+        )
         author = msg.author.split(" (", 1)[0] if msg.author else "Unknown"
 
         lines.append(f"{indent}\\` {msg_time} [{subject}]({msg.url}) {author}")

--- a/src/plugins/lkml_bot/renders/thread/renderer.py
+++ b/src/plugins/lkml_bot/renders/thread/renderer.py
@@ -4,12 +4,10 @@ Plugins 层渲染器：只负责渲染 Thread Overview。
 所有业务逻辑由 Service 层处理，发送由客户端处理。
 """
 
-from typing import Dict
+from typing import Dict, List
 
-from lkml.service import FeedMessage
 from lkml.service.types import (
-    ReplyMapEntry,
-    SubPatchOverviewData,
+    ThreadNode,
     ThreadOverviewData,
 )
 
@@ -43,140 +41,91 @@ class ThreadOverviewRenderer:
     ) -> DiscordRenderedThreadOverview:
         """渲染 Thread Overview 为 Discord 格式（不发送）
 
-        为每个 PATCH 渲染一条独立的消息。
-        - 系列 PATCH：为每个子 PATCH 渲染一条消息
-        - 单 PATCH：渲染一条 overview 消息
-
         Args:
             overview_data: Thread Overview 数据
 
         Returns:
             DiscordRenderedThreadOverview 渲染结果
         """
-
         messages: Dict[int, DiscordRenderedThreadMessage] = {}
 
-        # 使用 service 层准备好的 sub_patch_overviews
-        if overview_data.sub_patch_overviews:
-            content = self.render_overview_message(overview_data).content
+        if overview_data.root:
+            content = self._render_thread_tree(overview_data)
             messages[0] = DiscordRenderedThreadMessage(content=content, embed=None)
 
         return DiscordRenderedThreadOverview(messages=messages)
-
-    def render_sub_patch(
-        self, sub_overview: SubPatchOverviewData
-    ) -> DiscordRenderedThreadMessage:
-        """渲染单个子 PATCH 消息（用于更新）
-
-        Args:
-            sub_overview: 子 PATCH 的完整 Overview 数据
-
-        Returns:
-            DiscordRenderedThreadMessage 渲染结果
-        """
-        content = self._render_sub_patch(sub_overview)
-        return DiscordRenderedThreadMessage(content=content, embed=None)
 
     def render_overview_message(
         self, overview_data: ThreadOverviewData
     ) -> DiscordRenderedThreadMessage:
         """渲染 Thread Overview 为单条消息（用于更新）"""
-        content = self._render_overview_content(overview_data)
+        content = self._render_thread_tree(overview_data)
         return DiscordRenderedThreadMessage(content=content, embed=None)
 
-    def _render_sub_patch(self, sub_overview: SubPatchOverviewData) -> str:
-        """渲染单个子 PATCH 消息
+    def _render_thread_tree(self, overview_data: ThreadOverviewData) -> str:
+        """渲染完整层级树
 
         格式：
-        [subject](url)
+        [Cover Letter Subject](url)
 
-        ` 时间 作者
-            ` 时间 作者  # 子回复
-        ` 时间 作者
+        ` 2026-01-28 12:14 [RFC PATCH v1 1/2] Author
+            ` 2026-01-28 14:31 [Re: RFC PATCH v1 1/2] Reviewer
+        ` 2026-01-28 12:16 [RFC PATCH v1 2/2] Author
+        ` 2026-01-28 14:43 [Re: RFC PATCH v1 0/2] Reviewer
 
         Args:
-            sub_overview: 子 PATCH 的完整 Overview 数据（由 service 层准备）
+            overview_data: Thread Overview 数据（包含 root 层级树）
 
         Returns:
-            渲染后的子 PATCH 文本
+            渲染后的文本
         """
-        lines = []
-        patch = sub_overview.patch
+        if not overview_data.root:
+            return ""
 
-        lines.append(f"[{patch.subject}]({patch.url})")
+        lines = []
+        root = overview_data.root
+        patch_card = overview_data.patch_card
+
+        # 渲染根节点标题
+        lines.append(f"[{patch_card.subject}]({patch_card.url})")
         lines.append("")  # 空行
 
-        # 使用 service 层准备好的回复层级结构
-        reply_hierarchy = sub_overview.reply_hierarchy
-        reply_map = reply_hierarchy.reply_map
-        root_replies = reply_hierarchy.root_replies
-
-        if root_replies:
-            # 为该 PATCH 的每个顶层回复构建层级树
-            for root_reply_id in root_replies:
-                if root_reply_id in reply_map:
-                    root_reply = reply_map[root_reply_id].reply
-                    reply_lines = self._format_reply_tree(
-                        root_reply, reply_map, level=0
-                    )
-                    lines.extend(reply_lines)
+        # 渲染子节点
+        if root.children:
+            for child in root.children:
+                child_lines = self._render_tree_node(child, level=0)
+                lines.extend(child_lines)
         else:
             lines.append("_(No replies)_")
 
         return "\n".join(lines)
 
-    def _render_overview_content(self, overview_data: ThreadOverviewData) -> str:
-        """渲染所有子 PATCH 概览为单条消息内容"""
-        if not overview_data.sub_patch_overviews:
-            return ""
-
-        blocks = [
-            self._render_sub_patch(sub_overview)
-            for sub_overview in overview_data.sub_patch_overviews
-        ]
-        return "\n".join(blocks)
-
-    def _format_reply_tree(
-        self, reply: FeedMessage, reply_map: Dict[str, ReplyMapEntry], level: int
-    ) -> list:
-        """递归格式化回复树
-
-        格式：
-        ` 时间 作者 (邮箱)
-            ` 时间 作者 (邮箱)  # level=1
-                ` 时间 作者 (邮箱)  # level=2
+    def _render_tree_node(self, node: ThreadNode, level: int) -> List[str]:
+        """递归渲染树节点
 
         Args:
-            reply: 回复对象
-            reply_map: 回复映射 {message_id: ReplyMapEntry}
-            level: 层级深度（0 = 顶层）
+            node: ThreadNode 节点
+            level: 层级深度（0 = 顶层子节点）
 
         Returns:
             格式化后的行列表
         """
         lines = []
+        msg = node.message
 
         # 缩进：使用 tab 字符
         indent = "\t" * level
 
-        # 格式化当前回复：` 时间 作者 (邮箱)
-        subject = reply.subject.split("] ", 1)[0] + "]"
-        reply_time = reply.received_at.strftime("%Y-%m-%d %H:%M")
-        author = reply.author.split(" (", 1)[0] if reply.author else "Unknown"
+        # 格式化当前节点：` 时间 [subject](url) 作者
+        subject = msg.subject.split("] ", 1)[0] + "]"
+        msg_time = msg.received_at.strftime("%Y-%m-%d %H:%M") if msg.received_at else ""
+        author = msg.author.split(" (", 1)[0] if msg.author else "Unknown"
 
-        lines.append(f"{indent}\\` {reply_time} [{subject}]({reply.url}) {author}")
+        lines.append(f"{indent}\\` {msg_time} [{subject}]({msg.url}) {author}")
 
-        # 递归处理子回复
-        message_id = reply.message_id_header
-        if message_id in reply_map:
-            reply_entry = reply_map[message_id]
-            children_ids = reply_entry.children
-            for child_id in children_ids:
-                if child_id in reply_map:
-                    child_reply = reply_map[child_id].reply
-                    child_lines = self._format_reply_tree(
-                        child_reply, reply_map, level + 1
-                    )
-                    lines.extend(child_lines)
+        # 递归渲染子节点
+        for child in node.children:
+            child_lines = self._render_tree_node(child, level + 1)
+            lines.extend(child_lines)
 
         return lines


### PR DESCRIPTION
## Summary
- **Filter-first 持久化**: 只有匹配过滤规则的消息才写入 DB，减少无关数据存储
- **Per-subsystem feed 时间戳隔离**: 修复 `last_update_dt` 全局共享 bug，每个子系统独立维护时间戳，避免跨子系统的条目丢失
- **Thread Overview 统一层级树**: 重构 Discord / Feishu 线程渲染，使用统一的层级树结构
- **Reply 链回溯**: 支持 reply-to-reply 嵌套回复，沿 `in_reply_to` 链向上查找父 patch card
- **Thread backfill**: 从 lore.kernel.org 的 `t.mbox.gz` 拉取已有回复，补全线程概览
- **Gemini 摘要服务**: 可选的 AI patch 内容摘要，通过 `LKML_GEMINI_API_KEY` 启用
- **Patch Card 渲染增强**: 增加内容摘录和元数据，优化飞书卡片排版
- **杂项修复**: Discord 时间戳补充 UTC 后缀、migration runner 捕获 OperationalError

## Commits
- `acddb1f` refactor: simplify Thread Overview to use unified hierarchy tree
- `d60f384` feat: add optional Gemini content summarizer service
- `2561875` refactor: consolidate thread update path and integrate summarizer
- `bbc9c81` feat: enrich patch card rendering with content excerpts and metadata
- `3cf53fe` feat: improve thread overview Feishu card layout
- `14a4afd` fix: catch OperationalError in migration runner
- `71fd268` feat: filter-first persistence — only store tracked threads
- `bc4d213` fix: traverse reply chain for nested reply-to-reply
- `2a6c631` fix: add UTC suffix to Discord thread overview timestamps
- `6db45db` fix: use per-subsystem last_update_dt to prevent cross-subsystem timestamp skew